### PR TITLE
Clarify controller registration syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import { Application } from "stimulus";
 import { AutoSubmitFormController } from "stimulus-library";
 
 const application = Application.start();
-application.register("auto-submit-form-controller", AutoSubmitFormController);
+application.register("auto-submit-form", AutoSubmitFormController);
 ```
 
 ## Tree-shaking

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ import { AutoSubmitFormController } from "stimulus-library";
 
 const application = Application.start();
 application.register("auto-submit-form", AutoSubmitFormController);
+// Use kebab-case: `AutoSubmitFormController` -> `auto-submit-form`, `TurboFrameRefreshController` -> `turbo-frame-refresh`, etc.
 ```
 
 ## Tree-shaking

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -27,5 +27,5 @@ import { Application } from "stimulus";
 import { AutoSubmitFormController } from "stimulus-library";
 
 const application = Application.start();
-application.register("auto-submit-form-controller", AutoSubmitFormController);
+application.register("auto-submit-form", AutoSubmitFormController);
 ```

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -27,5 +27,8 @@ import { Application } from "stimulus";
 import { AutoSubmitFormController } from "stimulus-library";
 
 const application = Application.start();
+
 application.register("auto-submit-form", AutoSubmitFormController);
 ```
+
+> Use kebab-case when registering the controller: `AutoSubmitFormController` -> `auto-submit-form`, `TurboFrameRefreshController` -> `turbo-frame-refresh`, etc.


### PR DESCRIPTION
Thanks for this amazing library, I just started using it!

When I tried following the tutorial, the controller registration syntax from the examples didn't work.
The controllers were not actually registered.
I was scratching my head for a while trying to figure this out.

Here's the syntax from the current example:
```javascript
application.register("auto-submit-form-controller", AutoSubmitFormController);
```

The correct syntax is:
```javascript
application.register("auto-submit-form", AutoSubmitFormController);
```

(Without the `-controller` suffix).

The controller name should also be kebab-case, as [documented here](https://gist.github.com/mrmartineau/a4b7dfc22dc8312f521b42bb3c9a7c1e#naming-conventions)

This PR:
* Corrects the documentation to use the correct syntax
* Adds a note expressing the kebab-case requirement.