### PR TITLE
chore(examples): fix empty variable local storage key in example

### DIFF
--- a/examples/controllers/persisted_dismissable_controller.html
+++ b/examples/controllers/persisted_dismissable_controller.html
@@ -17,7 +17,7 @@
       <div
         class="alert alert-danger notice"
         data-controller="persisted-dismissable"
-        data-persisted-dismissable-key="dismissable-123"
+        data-persisted-dismissable-key-value="dismissable-123"
         role="notice"
       >
         <div class="text-center">


### PR DESCRIPTION
Hi,

This is a small fix in one of the examples.

The key was not actually used and the value would be stored on an empty localstorage key. This did work but was not what was to be demonstrated here.

bye,
Daniel