### PR TITLE
fix!(Controllers): All controllers should fire events named using the controller identifier instead of hardcoded names.

### DIFF
--- a/docs/docs/controllers/ajax/async_block_controller.mdx
+++ b/docs/docs/controllers/ajax/async_block_controller.mdx
@@ -36,11 +36,11 @@ AJAX load heavy content after the initial page load, while showing a placeholder
 
 ## Events
 
-| Event           | When                                                        | Dispatched on               | `event.detail` |
-|-----------------|-------------------------------------------------------------|-----------------------------|----------------|
-| `ajax:success`  | When the content is fetch successfully                      | the controller root element | -              |
-| `ajax:error`    | When the block fails to get a response from the endpoint    | the controller root element | -              |
-| `ajax:complete` | When the request finishes, regardless of success or failure | the controller root element | -              |
+| Event                  | When                                                        | Dispatched on               | `event.detail` |
+|------------------------|-------------------------------------------------------------|-----------------------------|----------------|
+| `async-block:success`  | When the content is fetch successfully                      | the controller root element | -              |
+| `async-block:error`    | When the block fails to get a response from the endpoint    | the controller root element | -              |
+| `async-block:complete` | When the request finishes, regardless of success or failure | the controller root element | -              |
 
 ## Side Effects
 <NoSideEffects/>

--- a/docs/docs/controllers/ajax/lazy_block_controller.mdx
+++ b/docs/docs/controllers/ajax/lazy_block_controller.mdx
@@ -35,8 +35,8 @@ AJAX load content, only when it comes into view, while showing a placeholder.
 
 ## Events
 
-| Event           | When                                                        | Dispatched on               | `event.detail` |
-|-----------------|-------------------------------------------------------------|-----------------------------|----------------|
+| Event                 | When                                                        | Dispatched on               | `event.detail` |
+|-----------------------|-------------------------------------------------------------|-----------------------------|----------------|
 | `lazy-block:success`  | When the content is fetch successfully                      | the controller root element | -              |
 | `lazy-block:error`    | When the block fails to get a response from the endpoint    | the controller root element | -              |
 | `lazy-block:complete` | When the request finishes, regardless of success or failure | the controller root element | -              |

--- a/docs/docs/controllers/ajax/lazy_block_controller.mdx
+++ b/docs/docs/controllers/ajax/lazy_block_controller.mdx
@@ -37,9 +37,9 @@ AJAX load content, only when it comes into view, while showing a placeholder.
 
 | Event           | When                                                        | Dispatched on               | `event.detail` |
 |-----------------|-------------------------------------------------------------|-----------------------------|----------------|
-| `ajax:success`  | When the content is fetch successfully                      | the controller root element | -              |
-| `ajax:error`    | When the block fails to get a response from the endpoint    | the controller root element | -              |
-| `ajax:complete` | When the request finishes, regardless of success or failure | the controller root element | -              |
+| `lazy-block:success`  | When the content is fetch successfully                      | the controller root element | -              |
+| `lazy-block:error`    | When the block fails to get a response from the endpoint    | the controller root element | -              |
+| `lazy-block:complete` | When the request finishes, regardless of success or failure | the controller root element | -              |
 
 ## Side Effects
 <NoSideEffects/>

--- a/docs/docs/controllers/ajax/load_block_controller.mdx
+++ b/docs/docs/controllers/ajax/load_block_controller.mdx
@@ -36,8 +36,8 @@ AJAX load heavy content after the initial page load, while showing a placeholder
 
 ## Events
 
-| Event           | When                                                        | Dispatched on               | `event.detail` |
-|-----------------|-------------------------------------------------------------|-----------------------------|----------------|
+| Event                 | When                                                        | Dispatched on               | `event.detail` |
+|-----------------------|-------------------------------------------------------------|-----------------------------|----------------|
 | `load-block:success`  | When the content is fetch successfully                      | the controller root element | -              |
 | `load-block:error`    | When the block fails to get a response from the endpoint    | the controller root element | -              |
 | `load-block:complete` | When the request finishes, regardless of success or failure | the controller root element | -              |

--- a/docs/docs/controllers/ajax/load_block_controller.mdx
+++ b/docs/docs/controllers/ajax/load_block_controller.mdx
@@ -38,9 +38,9 @@ AJAX load heavy content after the initial page load, while showing a placeholder
 
 | Event           | When                                                        | Dispatched on               | `event.detail` |
 |-----------------|-------------------------------------------------------------|-----------------------------|----------------|
-| `ajax:success`  | When the content is fetch successfully                      | the controller root element | -              |
-| `ajax:error`    | When the block fails to get a response from the endpoint    | the controller root element | -              |
-| `ajax:complete` | When the request finishes, regardless of success or failure | the controller root element | -              |
+| `load-block:success`  | When the content is fetch successfully                      | the controller root element | -              |
+| `load-block:error`    | When the block fails to get a response from the endpoint    | the controller root element | -              |
+| `load-block:complete` | When the request finishes, regardless of success or failure | the controller root element | -              |
 
 ## Side Effects
 <NoSideEffects/>

--- a/docs/docs/controllers/ajax/poll_block_controller.mdx
+++ b/docs/docs/controllers/ajax/poll_block_controller.mdx
@@ -39,9 +39,9 @@ AJAX load/refresh content periodically, at a configurable interval.
 
 | Event           | When                                                        | Dispatched on               | `event.detail` |
 |-----------------|-------------------------------------------------------------|-----------------------------|----------------|
-| `ajax:success`  | When the content is fetch successfully                      | the controller root element | -              |
-| `ajax:error`    | When the block fails to get a response from the endpoint    | the controller root element | -              |
-| `ajax:complete` | When the request finishes, regardless of success or failure | the controller root element | -              |
+| `poll-block:success`  | When the content is fetch successfully                      | the controller root element | -              |
+| `poll-block:error`    | When the block fails to get a response from the endpoint    | the controller root element | -              |
+| `poll-block:complete` | When the request finishes, regardless of success or failure | the controller root element | -              |
 
 ## Side Effects
 <NoSideEffects/>

--- a/docs/docs/controllers/ajax/poll_block_controller.mdx
+++ b/docs/docs/controllers/ajax/poll_block_controller.mdx
@@ -37,8 +37,8 @@ AJAX load/refresh content periodically, at a configurable interval.
 
 ## Events
 
-| Event           | When                                                        | Dispatched on               | `event.detail` |
-|-----------------|-------------------------------------------------------------|-----------------------------|----------------|
+| Event                 | When                                                        | Dispatched on               | `event.detail` |
+|-----------------------|-------------------------------------------------------------|-----------------------------|----------------|
 | `poll-block:success`  | When the content is fetch successfully                      | the controller root element | -              |
 | `poll-block:error`    | When the block fails to get a response from the endpoint    | the controller root element | -              |
 | `poll-block:complete` | When the request finishes, regardless of success or failure | the controller root element | -              |

--- a/docs/docs/controllers/form/detect_dirty_controller.mdx
+++ b/docs/docs/controllers/form/detect_dirty_controller.mdx
@@ -18,8 +18,8 @@ Adds `data-dirty` to the input being watched if it changes value, and removes it
 
 ## [Actions](https://stimulus.hotwire.dev/reference/actions)
 
-| Action | Purpose |
-| --- | --- |
+| Action    | Purpose                                |
+|-----------|----------------------------------------|
 | `restore` | Return the input to its original value |
 
 ## [Targets](https://stimulus.hotwire.dev/reference/targets)

--- a/docs/docs/controllers/form/enable_inputs_controller.mdx
+++ b/docs/docs/controllers/form/enable_inputs_controller.mdx
@@ -14,26 +14,26 @@ Provide actions to allow events to Enable/disable targeted inputs.
 
 ## [Actions](https://stimulus.hotwire.dev/reference/actions)
 
-| Action | Purpose |
-| --- | --- |
-| `enable` | Remove the `disabled` attribute from all `inputTarget`s |
-| `disable` | Add the `disabled` attribute from all `inputTarget`s |
+| Action    | Purpose                                                 |
+|-----------|---------------------------------------------------------|
+| `enable`  | Remove the `disabled` attribute from all `inputTarget`s |
+| `disable` | Add the `disabled` attribute from all `inputTarget`s    |
 
 
 ## [Targets](https://stimulus.hotwire.dev/reference/targets)
 
-| Target | Purpose | Default |
-| --- | --- | --- |
-| `enable` | The input(s) that will be enabled/disabled when the `enable`/`disable` actions are fired | - |
+| Target   | Purpose                                                                                  | Default |
+|----------|------------------------------------------------------------------------------------------|---------|
+| `enable` | The input(s) that will be enabled/disabled when the `enable`/`disable` actions are fired | -       |
 
 ## [Classes](https://stimulus.hotwire.dev/reference/classes)
 <NoClasses/>
 
 ## [Values](https://stimulus.hotwire.dev/reference/values)
 
-| Value | Type | Description | Default |
-| --- | --- | --- | --- |
-| `clear` | Boolean | Whether the controller should clear the values of the targeted inputs when they become disabled | false |
+| Value   | Type    | Description                                                                                     | Default |
+|---------|---------|-------------------------------------------------------------------------------------------------|---------|
+| `clear` | Boolean | Whether the controller should clear the values of the targeted inputs when they become disabled | false   |
 
 ## Events
 <NoEvents/>

--- a/docs/docs/controllers/form/limited_selection_checkboxes_controller.mdx
+++ b/docs/docs/controllers/form/limited_selection_checkboxes_controller.mdx
@@ -35,8 +35,8 @@ To only allow a user to select a limited number of checkboxes
 
 ## Events
 
-| Event                         | When                                              | Dispatched on                | `event.detail`                                      |
-|-------------------------------|---------------------------------------------------|------------------------------|-----------------------------------------------------|
+| Event                                    | When                                              | Dispatched on                | `event.detail`                                      |
+|------------------------------------------|---------------------------------------------------|------------------------------|-----------------------------------------------------|
 | `limited-selection-checkboxes:selection` | When the user checks a checkbox successfully      | the checkbox that was ticked | `target`: the element that the user selected        |
 | `limited-selection-checkboxes:too-many`  | When the user tries to select too many checkboxes | the checkbox that was ticked | `target`: the element that the user tried to select |
 

--- a/docs/docs/controllers/form/limited_selection_checkboxes_controller.mdx
+++ b/docs/docs/controllers/form/limited_selection_checkboxes_controller.mdx
@@ -37,8 +37,8 @@ To only allow a user to select a limited number of checkboxes
 
 | Event                         | When                                              | Dispatched on                | `event.detail`                                      |
 |-------------------------------|---------------------------------------------------|------------------------------|-----------------------------------------------------|
-| `limited-selection:selection` | When the user checks a checkbox successfully      | the checkbox that was ticked | `target`: the element that the user selected        |
-| `limited-selection:too-many`  | When the user tries to select too many checkboxes | the checkbox that was ticked | `target`: the element that the user tried to select |
+| `limited-selection-checkboxes:selection` | When the user checks a checkbox successfully      | the checkbox that was ticked | `target`: the element that the user selected        |
+| `limited-selection-checkboxes:too-many`  | When the user tries to select too many checkboxes | the checkbox that was ticked | `target`: the element that the user tried to select |
 
 ## Side Effects
 <NoSideEffects/>

--- a/docs/docs/controllers/general/empty_dom_controller.mdx
+++ b/docs/docs/controllers/general/empty_dom_controller.mdx
@@ -40,8 +40,8 @@ You can then style the controller, or show a nice placeholder when the container
 
 | Event           | When                                                        | Dispatched on          | `event.detail`                                                 |
 |-----------------|-------------------------------------------------------------|------------------------|----------------------------------------------------------------|
-| `dom:empty`     | When the subtree of the attached element becomes empty      | The controller element | -                                                              |
-| `dom:not-empty` | When the subtree of the attached element is no longer empty | The controller element | `count` - The number of matching elements that are now present |
+| `empty-dom:empty`     | When the subtree of the attached element becomes empty      | The controller element | -                                                              |
+| `empty-dom:not-empty` | When the subtree of the attached element is no longer empty | The controller element | `count` - The number of matching elements that are now present |
 
 ## Side Effects
 <NoSideEffects/>

--- a/docs/docs/controllers/general/empty_dom_controller.mdx
+++ b/docs/docs/controllers/general/empty_dom_controller.mdx
@@ -38,8 +38,8 @@ You can then style the controller, or show a nice placeholder when the container
 
 ## Events
 
-| Event           | When                                                        | Dispatched on          | `event.detail`                                                 |
-|-----------------|-------------------------------------------------------------|------------------------|----------------------------------------------------------------|
+| Event                 | When                                                        | Dispatched on          | `event.detail`                                                 |
+|-----------------------|-------------------------------------------------------------|------------------------|----------------------------------------------------------------|
 | `empty-dom:empty`     | When the subtree of the attached element becomes empty      | The controller element | -                                                              |
 | `empty-dom:not-empty` | When the subtree of the attached element is no longer empty | The controller element | `count` - The number of matching elements that are now present |
 

--- a/docs/docs/controllers/general/responsive_iframe_controller.mdx
+++ b/docs/docs/controllers/general/responsive_iframe_controller.mdx
@@ -21,7 +21,7 @@ To make seamless, responsive iframes that resize themselves to the size of their
 This behaviour uses two controllers.
 
 1. `ResponsiveIframeWrapperController`
-1. `ResponsiveIframeBodyController`
+2. `ResponsiveIframeBodyController`
 
 
 ## [Actions](https://stimulus.hotwire.dev/reference/actions)
@@ -86,4 +86,4 @@ The parent scope listens for messages from iframes, and when it receives a messa
 `iframe-body`, it will set the `height` of the iframe to the value passed.
 
 You can then set a `max-height` on the `<iframe>` to make sure it fits your design and never grows too large.
-You can either fix the width, or let it be responsive - the ResizeObserver inside the `<iframe>` will handle any size changes and adjust the height automatically to compensate. 
+You can either fix the width, or let it be responsive - the ResizeObserver inside the `<iframe>` will handle any size changes and adjust the height automatically to compensate.

--- a/docs/docs/controllers/signal/signal_visibility_controller.mdx
+++ b/docs/docs/controllers/signal/signal_visibility_controller.mdx
@@ -5,7 +5,6 @@ title: SignalVisibilityController
 
 
 import NoTargets from "../../_partials/no-targets.md";
-import NoEvents from "../../_partials/no-events.md";
 import NoActions from "../../_partials/no-actions.md";
 import NoSideEffects from "../../_partials/no-side-effects.md";
 import Expressions from "../../_partials/expressions.md";

--- a/src/controllers/ajax/load_block_controller.ts
+++ b/src/controllers/ajax/load_block_controller.ts
@@ -43,7 +43,7 @@ export class LoadBlockController extends BaseController {
 
     let failure = () => {
       el.replaceWith(this._errorMessage);
-      self.dispatchEvent(el, "ajax:error");
+      self.dispatchEvent(el, this.eventName("error"));
     };
 
     try {
@@ -62,11 +62,11 @@ export class LoadBlockController extends BaseController {
         el.replaceWith(...newEl.children);
       }
       // Trigger event to show block has loaded
-      self.dispatchEvent(el, "ajax:success");
+      self.dispatchEvent(el, this.eventName("success"));
     } catch (e) {
       failure();
     } finally {
-      self.dispatchEvent(el, "ajax:complete");
+      self.dispatchEvent(el, this.eventName("complete"));
     }
   }
 }

--- a/src/controllers/anchor_spy_controller.ts
+++ b/src/controllers/anchor_spy_controller.ts
@@ -49,11 +49,11 @@ export class AnchorSpyController extends BaseController {
 
   private _checkAnchor() {
     if (this._key === this._anchor) {
-      this.dispatchEvent(this.el, "anchor-spy:active");
+      this.dispatchEvent(this.el, this.eventName("active"));
       this.addActiveClasses(this.el);
       this.removeInactiveClasses(this.el);
     } else {
-      this.dispatchEvent(this.el, "anchor-spy:inactive");
+      this.dispatchEvent(this.el, this.eventName("inactive"));
       this.addInactiveClasses(this.el);
       this.removeActiveClasses(this.el);
     }

--- a/src/controllers/confirm_controller.ts
+++ b/src/controllers/confirm_controller.ts
@@ -34,7 +34,7 @@ export class ConfirmController extends BaseController {
   confirm(event: Event) {
     if (!(window.confirm(this._message))) {
       event.preventDefault();
-      this.dispatchEvent(this.el, "confirm:cancelled");
+      this.dispatchEvent(this.el, this.eventName("cancelled"));
     }
   }
 

--- a/src/controllers/element_save_controller.ts
+++ b/src/controllers/element_save_controller.ts
@@ -68,7 +68,7 @@ export class ElementSaveController extends BaseController {
       event.preventDefault();
     }
     this._store.clear();
-    this.dispatchEvent(this._element, `element-save:cleared`);
+    this.dispatchEvent(this._element, this.eventName("cleared"));
   }
 
   save(event?: Event) {
@@ -80,7 +80,7 @@ export class ElementSaveController extends BaseController {
     let data: { [idx: string]: any } = {};
     attributes.forEach((attr: string) => data[attr] = _get(element, attr));
     this._store.value = data;
-    this.dispatchEvent(element, `element-save:save:success`);
+    this.dispatchEvent(element, this.eventName("save:success"));
   }
 
   restore(event?: Event) {
@@ -93,9 +93,9 @@ export class ElementSaveController extends BaseController {
       Object.keys(savedData).forEach(
         (attr: string) => _set(element as HTMLElement, attr, savedData[attr]),
       );
-      this.dispatchEvent(element, `element-save:restore:success`);
+      this.dispatchEvent(element, this.eventName("restore:success"));
     } else {
-      this.dispatchEvent(element, `element-save:restore:empty`);
+      this.dispatchEvent(element, this.eventName("restore:empty"));
     }
   }
 

--- a/src/controllers/empty_dom_controller.ts
+++ b/src/controllers/empty_dom_controller.ts
@@ -48,11 +48,11 @@ export class EmptyDomController extends BaseController {
     if (children.length === 0) {
       this.removeNotEmptyClasses();
       this.addEmptyClasses();
-      this.dispatchEvent(element as HTMLElement, "dom:empty");
+      this.dispatchEvent(element as HTMLElement, this.eventName("empty"));
     } else {
       this.addNotEmptyClasses();
       this.removeEmptyClasses();
-      this.dispatchEvent(element as HTMLElement, "dom:not-empty", {detail: {count: children.length}});
+      this.dispatchEvent(element as HTMLElement, this.eventName("not-empty"), {detail: {count: children.length}});
     }
   }
 

--- a/src/controllers/forms/form_save_controller.ts
+++ b/src/controllers/forms/form_save_controller.ts
@@ -90,7 +90,7 @@ export class FormSaveController extends BaseController {
 
   _clear() {
     localStorage.removeItem(this._formIdentifier);
-    this.dispatchEvent(this.el, `form-save:cleared`);
+    this.dispatchEvent(this.el, this.eventName(`cleared`));
   }
 
   clear(event?: Event) {
@@ -102,7 +102,7 @@ export class FormSaveController extends BaseController {
     event.preventDefault();
     let data = this._formData;
     localStorage.setItem(this._formIdentifier, JSON.stringify(data[this._formIdentifier]));
-    this.dispatchEvent(this.el, `form-save:save:success`);
+    this.dispatchEvent(this.el, this.eventName(`save:success`));
   }
 
   restore(event?: Event) {
@@ -123,9 +123,9 @@ export class FormSaveController extends BaseController {
           }
         }
       }
-      this.dispatchEvent(this.el, `form-save:restore:success`);
+      this.dispatchEvent(this.el, this.eventName(`restore:success`));
     } else {
-      this.dispatchEvent(this.el, `form-save:restore:empty`);
+      this.dispatchEvent(this.el, this.eventName(`restore:empty`));
     }
   }
 

--- a/src/controllers/forms/limited_selection_checkboxes_controller.ts
+++ b/src/controllers/forms/limited_selection_checkboxes_controller.ts
@@ -24,12 +24,12 @@ export class LimitedSelectionCheckboxesController extends BaseController {
       event.preventDefault();
       target.checked = false;
       this.dispatchEvent(target, "change");
-      this.dispatchEvent(target, "limited-selection:too-many");
+      this.dispatchEvent(target, this.eventName("too-many"));
       if (this.hasErrorTarget && this.hasMessageValue) {
         this.errorTarget.innerHTML = this.messageValue;
       }
     } else {
-      this.dispatchEvent(target, "limited-selection:selection");
+      this.dispatchEvent(target, this.eventName("selection"));
       if (this.hasErrorTarget) {
         this.errorTarget.innerHTML = "";
       }

--- a/src/controllers/forms/password_confirm_controller.ts
+++ b/src/controllers/forms/password_confirm_controller.ts
@@ -25,10 +25,10 @@ export class PasswordConfirmController extends BaseController {
   private _checkPasswordsMatch() {
     let element = this.el;
     if (this._allPasswordsMatch()) {
-      this.dispatchEvent(element, "password-confirm:match");
+      this.dispatchEvent(element, this.eventName("match"));
       this.passwordTargets.forEach(el => this.removeErrorClasses(el));
     } else {
-      this.dispatchEvent(element, "password-confirm:no-match");
+      this.dispatchEvent(element, this.eventName("no-match"));
       this.passwordTargets.forEach(el => this.addErrorClasses(el));
     }
   }

--- a/src/controllers/forms/remote_form_controller.ts
+++ b/src/controllers/forms/remote_form_controller.ts
@@ -26,7 +26,7 @@ export class RemoteFormController extends BaseController {
         throw new Error('expected form to have a DOM parent, could not execute replaceChild');
       }
       parentNode.replaceChild(newElement, this.el);
-      this.dispatchEvent(newElement, 'remote-form:replace');
+      this.dispatchEvent(newElement, this.eventName('replace'));
     } else {
       console.log('Unknown', data);
     }

--- a/src/controllers/media/fallback_image_controller.ts
+++ b/src/controllers/media/fallback_image_controller.ts
@@ -44,11 +44,11 @@ export class FallbackImageController extends BaseController {
     this.addFailClasses();
 
     if (this.hasPlaceholderValue && element.src !== this.placeholderValue) {
-      this.dispatchEvent(element, "fallback-image:placeholder");
+      this.dispatchEvent(element, this.eventName("placeholder"));
       element.src = this.placeholderValue;
       element.onerror = this._fail;
     } else {
-      this.dispatchEvent(element, "fallback-image:fail");
+      this.dispatchEvent(element, this.eventName("fail"));
       element.style.display = "none";
     }
   }

--- a/src/controllers/teleport_controller.ts
+++ b/src/controllers/teleport_controller.ts
@@ -28,7 +28,7 @@ export class TeleportController extends EphemeralController {
     let destination = document.querySelector(this.targetValue);
 
     if (destination == null) {
-      this.dispatchEvent(element, "teleport:error");
+      this.dispatchEvent(element, this.eventName("error"));
       return;
     }
 

--- a/src/controllers/utility/intersection_controller.ts
+++ b/src/controllers/utility/intersection_controller.ts
@@ -23,11 +23,11 @@ export class IntersectionController extends BaseController {
   }
 
   appear(entry: IntersectionObserverEntry) {
-    dispatchEvent(this, this.el, "intersection:appear");
+    dispatchEvent(this, this.el, this.eventName("appear"));
   };
 
   disappear(entry: IntersectionObserverEntry) {
-    dispatchEvent(this, this.el, "intersection:disappear");
+    dispatchEvent(this, this.el, this.eventName("disappear"));
   };
 
 }

--- a/src/controllers/utility/interval_controller.ts
+++ b/src/controllers/utility/interval_controller.ts
@@ -18,7 +18,7 @@ export class IntervalController extends BaseController {
   }
 
   _interval() {
-    this.dispatchEvent(this.el, "interval:action");
+    this.dispatchEvent(this.el, this.eventName("action"));
   }
 
 }

--- a/src/controllers/utility/user_focus_controller.ts
+++ b/src/controllers/utility/user_focus_controller.ts
@@ -12,11 +12,11 @@ export class UserFocusController extends BaseController {
   }
 
   appear() {
-    this.dispatchEvent(this.el, "user-focus:active");
+    this.dispatchEvent(this.el, this.eventName("active"));
   }
 
   away() {
-    this.dispatchEvent(this.el, "user-focus:away");
+    this.dispatchEvent(this.el, this.eventName("away"));
   }
 
   private _handleVisibility() {

--- a/src/controllers/visual/countdown_controller.ts
+++ b/src/controllers/visual/countdown_controller.ts
@@ -34,7 +34,7 @@ export class CountdownController extends BaseController {
   declare removeCountingDownClasses: (el?: HTMLElement) => void;
 
   // Instance Data
-  _interval: null | ReturnType<typeof window.setInterval> = null;
+  _timeout: null | ReturnType<typeof window.setTimeout> = null;
 
   get _removeUnused(): boolean {
     return this.hasRemoveUnusedValue ? this.removeUnusedValue : false;
@@ -44,8 +44,13 @@ export class CountdownController extends BaseController {
     return new Date(this.deadlineValue);
   }
 
+  initialize() {
+    this._tick = this._tick.bind(this);
+  }
+
   connect() {
-    this._interval = setInterval(this._tick.bind(this), 1000);
+    this._timeout = setTimeout(this._tick, 1000);
+    console.log(this._timeout);
     installClassMethods(this);
     this.addCountingDownClasses();
   }
@@ -58,8 +63,8 @@ export class CountdownController extends BaseController {
 
   deadlineValueChanged() {
     // Countdown had previously ended, restart ticking. Updating mid-tick will just work.
-    if (this._interval == null) {
-      this._interval = setInterval(this._tick.bind(this), 1000);
+    if (this._timeout == null) {
+      this._timeout = setTimeout(this._tick, 1000);
     }
   }
 
@@ -75,8 +80,10 @@ export class CountdownController extends BaseController {
         this.removeCountingDownClasses();
         this.addEndedClasses();
         this.dispatchEvent(this.el, "countdown:ended");
+        return;
       } else {
         distance = intervalToDuration({start: this._deadlineDate, end: now});
+        this._timeout = setTimeout(this._tick, 1000);
       }
 
       if (this.hasYearsTarget) {
@@ -104,9 +111,9 @@ export class CountdownController extends BaseController {
   }
 
   _clearTick() {
-    if (this._interval) {
-      clearInterval(this._interval);
-      this._interval = null;
+    if (this._timeout) {
+      clearTimeout(this._timeout);
+      this._timeout = null;
     }
   }
 

--- a/src/controllers/visual/countdown_controller.ts
+++ b/src/controllers/visual/countdown_controller.ts
@@ -79,7 +79,7 @@ export class CountdownController extends BaseController {
         this._clearTick();
         this.removeCountingDownClasses();
         this.addEndedClasses();
-        this.dispatchEvent(this.el, "countdown:ended");
+        this.dispatchEvent(this.el, this.eventName("ended"));
         return;
       } else {
         distance = intervalToDuration({start: this._deadlineDate, end: now});


### PR DESCRIPTION
Allows users to alias and rename controllers and get event names that match the controller name.

Breaking event name changes:
- EmptyDomController
- LimitedSelectionCheckboxesController
- LoadBlockController
- AsyncBlockController
- LazyBlockController
- PollBlockController