### PR TITLE
refactor!(deps): Remove polyfills and internalize key dependencies instead of importing entire libraries

### DIFF
--- a/docs/docs/controllers/media/lightbox_image_controller.mdx
+++ b/docs/docs/controllers/media/lightbox_image_controller.mdx
@@ -55,16 +55,13 @@ This controller needs to be mounted on an `<img>` tag to work.
 On the `open` action - the controller will create a `<dialog>` element, insert it into the DOM after the controller root element, and immediately open it. You will want to style this according to your application, some examples are given below.
 The `<dialog>` will have only one element inside of it, a new `<img>` with the `src`, `srcset` and `sizes` attributes either taken from the values API or copied from the controller root element.
 
-This uses the [DialogPolyfill](https://github.com/GoogleChrome/dialog-polyfill) library to make sure this behaviour is compatible with all browsers, but as such, is subject to the same limitations.
 
-In particular - when styling the `::backdrop`(https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop) you will need to style both `dialog::backdrop` and `dialog + .backdrop` to account for the polyfilled behaviour.
+### Polyfills
 
-### Warning
+If you are building applications for browser versions that do not support the `<dialog>` element,
+you will need to include the [dialog-polyfill](https://github.com/GoogleChrome/dialog-polyfill).
 
-While in testing, this component has always performed perfectly - the polyfill mentioned above warns that if you experience issues with stacking contexts, and the dialogue not properly rendering at the topmost Z-Index, it is likely due to your browser having poor support for `<dialog>` and this library being able
-to fully mock the behaviour. [See the limitations section of DialogPolyfill](https://github.com/GoogleChrome/dialog-polyfill#limitations) for more
-information.
-
+This is not included in the Stimulus library.
 
 
 <iframe

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,9 @@
         "@babel/runtime": "^7.20.13",
         "@hotwired/stimulus": "^3.2.1",
         "date-fns": "^2.29.3",
-        "mitt": "^3.0.0",
-        "smoothscroll-polyfill": "^0.4.4"
+        "mitt": "^3.0.0"
       },
       "devDependencies": {
-        "@types/smoothscroll-polyfill": "^0.3.1",
         "agadoo": "^3.0.0",
         "cypress": "^12.5.1",
         "fast-glob": "^3.2.12",
@@ -638,12 +636,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-      "dev": true
-    },
-    "node_modules/@types/smoothscroll-polyfill": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/smoothscroll-polyfill/-/smoothscroll-polyfill-0.3.1.tgz",
-      "integrity": "sha512-+KkHw4y+EyeCtVXET7woHUhIbfWFCflc0E0mZnSV+ZdjPQeHt/9KPEuT7gSW/kFQ8O3EG30PLO++YhChDt8+Ag==",
       "dev": true
     },
     "node_modules/@types/yauzl": {
@@ -3904,11 +3896,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/smoothscroll-polyfill": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
-      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4944,12 +4931,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-      "dev": true
-    },
-    "@types/smoothscroll-polyfill": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/smoothscroll-polyfill/-/smoothscroll-polyfill-0.3.1.tgz",
-      "integrity": "sha512-+KkHw4y+EyeCtVXET7woHUhIbfWFCflc0E0mZnSV+ZdjPQeHt/9KPEuT7gSW/kFQ8O3EG30PLO++YhChDt8+Ag==",
       "dev": true
     },
     "@types/yauzl": {
@@ -7362,11 +7343,6 @@
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
       }
-    },
-    "smoothscroll-polyfill": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
-      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,10 @@
         "@hotwired/stimulus": "^3.2.1",
         "date-fns": "^2.29.3",
         "dialog-polyfill": "^0.5.6",
-        "lodash-es": "^4.17.21",
         "mitt": "^3.0.0",
         "smoothscroll-polyfill": "^0.4.4"
       },
       "devDependencies": {
-        "@types/lodash-es": "^4.17.6",
         "@types/smoothscroll-polyfill": "^0.3.1",
         "agadoo": "^3.0.0",
         "cypress": "^12.5.1",
@@ -611,21 +609,6 @@
         "rollup": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
-      "dev": true
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.6.tgz",
-      "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
       }
     },
     "node_modules/@types/minimist": {
@@ -2802,11 +2785,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -4944,21 +4922,6 @@
       "dev": true,
       "requires": {}
     },
-    "@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
-      "dev": true
-    },
-    "@types/lodash-es": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.6.tgz",
-      "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -6602,11 +6565,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.ismatch": {
       "version": "4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@babel/runtime": "^7.20.13",
         "@hotwired/stimulus": "^3.2.1",
         "date-fns": "^2.29.3",
-        "dialog-polyfill": "^0.5.6",
         "mitt": "^3.0.0",
         "smoothscroll-polyfill": "^0.4.4"
       },
@@ -1654,11 +1653,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dialog-polyfill": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz",
-      "integrity": "sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w=="
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -5704,11 +5698,6 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
-    },
-    "dialog-polyfill": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz",
-      "integrity": "sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w=="
     },
     "dot-prop": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@babel/runtime": "^7.20.13",
     "@hotwired/stimulus": "^3.2.1",
     "date-fns": "^2.29.3",
-    "dialog-polyfill": "^0.5.6",
     "mitt": "^3.0.0",
     "smoothscroll-polyfill": "^0.4.4"
   },

--- a/package.json
+++ b/package.json
@@ -38,12 +38,10 @@
     "@hotwired/stimulus": "^3.2.1",
     "date-fns": "^2.29.3",
     "dialog-polyfill": "^0.5.6",
-    "lodash-es": "^4.17.21",
     "mitt": "^3.0.0",
     "smoothscroll-polyfill": "^0.4.4"
   },
   "devDependencies": {
-    "@types/lodash-es": "^4.17.6",
     "@types/smoothscroll-polyfill": "^0.3.1",
     "agadoo": "^3.0.0",
     "cypress": "^12.5.1",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,9 @@
     "@babel/runtime": "^7.20.13",
     "@hotwired/stimulus": "^3.2.1",
     "date-fns": "^2.29.3",
-    "mitt": "^3.0.0",
-    "smoothscroll-polyfill": "^0.4.4"
+    "mitt": "^3.0.0"
   },
   "devDependencies": {
-    "@types/smoothscroll-polyfill": "^0.3.1",
     "agadoo": "^3.0.0",
     "cypress": "^12.5.1",
     "fast-glob": "^3.2.12",

--- a/src/controllers/element_save_controller.ts
+++ b/src/controllers/element_save_controller.ts
@@ -1,6 +1,5 @@
 import debounce from "../utilities/debounce";
-import _get from "lodash-es/get";
-import _set from "lodash-es/set";
+import { get as _get, set as _set } from "../utilities/get_set";
 import {BaseController} from '../utilities/base_controller';
 import {LocalStorageProxy, useLocalStorage} from "../mixins";
 

--- a/src/controllers/element_save_controller.ts
+++ b/src/controllers/element_save_controller.ts
@@ -1,4 +1,4 @@
-import debounce from "lodash-es/debounce";
+import debounce from "../utilities/debounce";
 import _get from "lodash-es/get";
 import _set from "lodash-es/set";
 import {BaseController} from '../utilities/base_controller';

--- a/src/controllers/equalize_controller.ts
+++ b/src/controllers/equalize_controller.ts
@@ -1,5 +1,5 @@
 import {BaseController} from "../utilities/base_controller";
-import debounce from "lodash-es/debounce";
+import debounce from "../utilities/debounce";
 import {useIntersection} from "../mixins/use_intersection";
 
 export class EqualizeController extends BaseController {

--- a/src/controllers/forms/navigate_form_errors_controller.ts
+++ b/src/controllers/forms/navigate_form_errors_controller.ts
@@ -1,6 +1,6 @@
 import {BaseController} from "../../utilities/base_controller";
 import {scrollToElement} from "../../utilities/scroll";
-import clamp from "lodash-es/clamp";
+import { clamp } from "../../utilities/numbers"
 import {installClassMethods} from "../../mixins/install_class_methods";
 
 export class NavigateFormErrorsController extends BaseController {

--- a/src/controllers/media/lightbox_image_controller.ts
+++ b/src/controllers/media/lightbox_image_controller.ts
@@ -1,4 +1,3 @@
-import dialogPolyfill from "dialog-polyfill";
 import {BaseController} from "../../utilities/base_controller";
 import {scrollToElement} from "../../utilities/scroll";
 import {useEventListener} from "../../mixins/use_event_listener";
@@ -71,9 +70,7 @@ export class LightboxImageController extends BaseController {
     this._dialog.appendChild(image);
 
     element.insertAdjacentElement("afterend", this._dialog);
-    dialogPolyfill.registerDialog(this._dialog);
     this._dialog.className = this._modalClassName;
-    // @ts-ignore Experimental API
     this._dialog.showModal();
     scrollToElement(this._dialog, {behavior: "smooth", block: "end"}).catch(() => this._dialog!.scrollIntoView(false));
     useEventListener(this, this._dialog, "click", this.close);

--- a/src/controllers/temporary_state_controller.ts
+++ b/src/controllers/temporary_state_controller.ts
@@ -1,6 +1,5 @@
 import { camelCase } from '../utilities/strings'
-import _get from "lodash-es/get";
-import _set from "lodash-es/set";
+import { get as _get, set as _set } from "../utilities/get_set";
 import {EphemeralController} from "../utilities/ephemeral_controller";
 import {useTimeout} from "../mixins/use_timeout";
 import "../polyfills/string.replaceAll";

--- a/src/controllers/temporary_state_controller.ts
+++ b/src/controllers/temporary_state_controller.ts
@@ -1,4 +1,4 @@
-import camelCase from "lodash-es/camelCase";
+import { camelCase } from '../utilities/strings'
 import _get from "lodash-es/get";
 import _set from "lodash-es/set";
 import {EphemeralController} from "../utilities/ephemeral_controller";

--- a/src/controllers/visual/tabs_controller.ts
+++ b/src/controllers/visual/tabs_controller.ts
@@ -1,7 +1,7 @@
-import {BaseController} from "../../utilities/base_controller";
-import clamp from "lodash-es/clamp";
-import {useCollectionEventListener} from "../../mixins/use_event_listener";
-import {installClassMethods} from "../../mixins/install_class_methods";
+import { BaseController } from "../../utilities/base_controller";
+import { clamp } from "../../utilities/numbers";
+import { useCollectionEventListener } from "../../mixins/use_event_listener";
+import { installClassMethods } from "../../mixins/install_class_methods";
 
 export class TabsController extends BaseController {
 

--- a/src/mixins/use_event_bus.ts
+++ b/src/mixins/use_event_bus.ts
@@ -1,8 +1,8 @@
-import {Controller} from "@hotwired/stimulus";
-import debounce from "lodash-es/debounce";
-import {EventBus} from "../utilities/event_bus";
-import {wrapArray} from "../utilities/arrays";
-import {useMixin} from "./create_mixin";
+import { Controller } from "@hotwired/stimulus";
+import debounce from '../utilities/debounce';
+import { EventBus } from "../utilities/event_bus";
+import { wrapArray } from "../utilities/arrays";
+import { useMixin } from "./create_mixin";
 
 export function useEventBus(controller: Controller, eventNameOrNames: string | string[], handler: (...args: any[]) => void, opts?: { debounce?: number }) {
   let options = opts;

--- a/src/mixins/use_event_listener.ts
+++ b/src/mixins/use_event_listener.ts
@@ -1,5 +1,5 @@
 import {Controller} from "@hotwired/stimulus";
-import debounce from "lodash-es/debounce";
+import debounce from "../utilities/debounce";
 import {wrapArray} from "../utilities/arrays";
 import {useMixin} from "./create_mixin";
 

--- a/src/utilities/debounce.ts
+++ b/src/utilities/debounce.ts
@@ -1,0 +1,23 @@
+export default function debounce<T extends (...args: any[]) => any>(
+  func: T,
+  wait: number,
+  immediate = false,
+): T {
+  let timeout: ReturnType<typeof window.setTimeout> | null;
+  return function (this: any, ...args: any[]) {
+    const later = () => {
+      timeout = null;
+      if (!immediate) {
+        func.apply(this, args);
+      }
+    };
+    const callNow = immediate && !timeout;
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(later, wait);
+    if (callNow) {
+      func.apply(this, args);
+    }
+  } as T;
+}

--- a/src/utilities/ephemeral_controller.ts
+++ b/src/utilities/ephemeral_controller.ts
@@ -1,4 +1,4 @@
-import camelCase from "lodash-es/camelCase";
+import { camelCase } from "../utilities/strings";
 import {BaseController} from "./base_controller";
 import '../polyfills/string.replaceAll';
 

--- a/src/utilities/get_set.ts
+++ b/src/utilities/get_set.ts
@@ -1,0 +1,254 @@
+// The following code is extracted and modified from lodash v4.17.21
+// Original copyright and license information is below.
+//
+// The MIT License
+//
+// Copyright JS Foundation and other contributors <https://js.foundation/>
+//
+// Based on Underscore.js, copyright Jeremy Ashkenas,
+// DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+//
+// This software consists of voluntary contributions made by many
+// individuals. For exact contribution history, see the revision history
+// available at https://github.com/lodash/lodash
+//
+// The following license applies to all parts of this software except as
+// documented below:
+//
+// ====
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// ====
+//
+// Copyright and related rights for sample code are waived via CC0. Sample
+// code is defined as all source code displayed within the prose of the
+// documentation.
+//
+// CC0: http://creativecommons.org/publicdomain/zero/1.0/
+//
+// ====
+
+/** Used to match property names within property paths. */
+const reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/;
+const reIsPlainProp = /^\w*$/;
+const rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
+const reIsUint = /^(?:0|[1-9]\d*)$/;
+const reEscapeChar = /\\(\\)?/g;
+const symbolTag = '[object Symbol]';
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+const isArray = Array.isArray;
+const symbolProto = Symbol ? Symbol.prototype : undefined;
+const symbolValueOf = symbolProto ? symbolProto.valueOf : undefined;
+const symbolToString = symbolProto ? symbolProto.toString : undefined;
+
+const INFINITY = 1 / 0;
+const MAX_SAFE_INTEGER = 9007199254740991;
+const MAX_INTEGER = 1.7976931348623157e+308;
+const NAN = 0 / 0;
+
+function arrayMap<T>(array: T[] | null, iteratee: (value: T, index: number, array: T[]) => any): any[] {
+  let index = -1;
+  const length = array == null ? 0 : array.length;
+  const result = Array(length);
+
+  while (++index < length) {
+    result[index] = iteratee(array![index], index, array!);
+  }
+  return result;
+}
+
+function baseToString(value: any): string {
+  // Exit early for strings to avoid a performance hit in some environments.
+  if (typeof value == 'string') {
+    return value;
+  }
+  if (isArray(value)) {
+    // Recursively convert values (susceptible to call stack limits).
+    return arrayMap(value, baseToString) + '';
+  }
+  if (isSymbol(value)) {
+    return symbolToString ? symbolToString.call(value) : '';
+  }
+  const result = (value + '');
+  return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result;
+}
+
+function toString(value: any): string {
+  return value == null ? '' : baseToString(value);
+}
+
+export function stringToPath(str: string): string[] {
+  const result = [];
+  if (str.charCodeAt(0) === 46 /* . */) {
+    result.push('');
+  }
+  // @ts-ignore
+  str.replace(rePropName, function (match, number, quote, subString) {
+    result.push(quote ? subString.replace(reEscapeChar, '$1') : (number || match));
+  });
+  return result;
+}
+
+function defineProperty<T extends object>(object: T, key: any, value: any): T {
+  // @ts-ignore
+  object[key] = value;
+  return object;
+}
+
+function castPath(value: any, object: object) {
+  if (isArray(value)) {
+    return value;
+  }
+  return isKey(value, object) ? [value] : stringToPath(toString(value));
+}
+
+function toKey(value: any): string | Symbol {
+  if (typeof value == 'string' || isSymbol(value)) {
+    return value;
+  }
+  let result = (value + '');
+  return (result == '0' && (1 / value) == -Infinity) ? '-0' : result;
+}
+
+function isKey<T extends object>(value: any, object: T): value is keyof T {
+  if (isArray(value)) {
+    return false;
+  }
+  let type = typeof value;
+  if (type == 'number' || type == 'boolean' ||
+    value == null || isSymbol(value)) {
+    return true;
+  }
+  return reIsPlainProp.test(value) || !reIsDeepProp.test(value) ||
+    (object != null && value in Object(object));
+}
+
+function isObjectLike<T>(value: T): boolean {
+  return value != null && typeof value == 'object';
+}
+
+function isSymbol<T>(value: T): boolean {
+  return typeof value == 'symbol' ||
+    (isObjectLike(value) && baseGetTag(value) == symbolTag);
+}
+
+function baseGetTag<T>(value: T): string {
+  // @ts-ignore
+  return objectToString.call(value);
+}
+
+function objectToString<T>(value: T): string {
+  return objectProto.toString.call(value);
+}
+
+const objectProto = Object.prototype;
+
+function baseGet(object: object, path: string): any {
+  let castedPath = castPath(path, object);
+
+  let index = 0;
+  const length = castedPath.length;
+
+  while (object != null && index < length) {
+    // @ts-ignore
+    object = object[toKey(castedPath[index++])];
+  }
+  return (index && index == length) ? object : undefined;
+}
+
+function isObject<T>(value: T): boolean {
+  const type = typeof value;
+  return value != null && (type == 'object' || type == 'function');
+}
+
+function isIndex<T>(value: T, length: number | null = null): boolean {
+  let type = typeof value;
+  length = length == null ? MAX_SAFE_INTEGER : length;
+
+  // @ts-ignore
+  return !!length && (type == 'number' || (type != 'symbol' && reIsUint.test(value))) && (value > -1 && value % 1 == 0 && value < length);
+}
+
+function eq(value: any, other: any): boolean {
+  return value === other || (value !== value && other !== other);
+}
+
+function assignValue<T extends object>(object: T, key: any, value: any) {
+  // @ts-ignore
+  const objValue = object[key];
+  if (!(hasOwnProperty.call(object, key) && eq(objValue, value)) ||
+    (value === undefined && !(key in object))) {
+    baseAssignValue(object, key, value);
+  }
+}
+
+function baseAssignValue<T extends object>(object: T, key: any, value: any) {
+  if (key == '__proto__' && defineProperty) {
+    defineProperty(object, key, {
+      'configurable': true,
+      'enumerable': true,
+      'value': value,
+      'writable': true,
+    });
+  } else {
+    // @ts-ignore
+    object[key] = value;
+  }
+}
+
+
+function baseSet<T extends Object>(object: T, path: string, value: any) {
+  if (!isObject(object)) {
+    return object;
+  }
+  let castedPath = castPath(path, object);
+
+  let index = -1;
+  const length = castedPath.length;
+  const lastIndex = length - 1;
+
+  let nested = object;
+  while (nested != null && ++index < length) {
+    const key = toKey(castedPath[index]);
+    let newValue = value;
+
+    if (index != lastIndex) {
+      // @ts-ignore
+      const objValue = nested[key];
+      newValue = isObject(objValue)
+        ? objValue
+        : (isIndex(castedPath[index + 1]) ? [] : {});
+    }
+    assignValue(nested, key, newValue);
+    // @ts-ignore
+    nested = nested[key];
+  }
+  return object;
+}
+
+export function get<T extends object>(object: T, path: string, defaultValue: any = null): any {
+  const result = object == null ? undefined : baseGet(object, path);
+  return result === undefined ? defaultValue : result;
+}
+
+export function set<T extends object>(object: T, path: string, value: any): any {
+  return object == null ? object : baseSet(object, path, value);
+}

--- a/src/utilities/numbers.ts
+++ b/src/utilities/numbers.ts
@@ -1,0 +1,3 @@
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/utilities/scroll.ts
+++ b/src/utilities/scroll.ts
@@ -1,17 +1,12 @@
-import smoothScroll from 'smoothscroll-polyfill';
-
 export async function scrollToElement(element: Element, {behavior = "smooth", block = "start", inline = "nearest"}: ScrollIntoViewOptions = {}) {
-  smoothScroll.polyfill();
   element.scrollIntoView({behavior, block, inline});
 }
 
 export async function scrollAbsoluteTop(element: Window | Element, {behavior = "smooth"}: ScrollOptions = {}) {
-  smoothScroll.polyfill();
   element.scrollTo({top: 0, left: 0, behavior});
 }
 
 export async function scrollAbsoluteBottom(element: Window | Element, {behavior = "smooth"}: ScrollOptions = {}) {
-  smoothScroll.polyfill();
   if (element == window) {
     element.scrollTo({top: document.body.scrollHeight, left: 0, behavior});
   } else {
@@ -20,12 +15,10 @@ export async function scrollAbsoluteBottom(element: Window | Element, {behavior 
 }
 
 export async function scrollAbsoluteLeft(element: Window | Element, {behavior = "smooth"}: ScrollOptions = {}) {
-  smoothScroll.polyfill();
   element.scrollTo({left: 0, behavior});
 }
 
 export async function scrollAbsoluteRight(element: Window | Element, {behavior = "smooth"}: ScrollOptions = {}) {
-  smoothScroll.polyfill();
   if (element == window) {
     element.scrollTo({left: document.body.scrollWidth, behavior});
   } else {
@@ -34,27 +27,22 @@ export async function scrollAbsoluteRight(element: Window | Element, {behavior =
 }
 
 export async function scrollUp(element: Window | Element, amount: number, {behavior = "smooth"}: ScrollOptions = {}) {
-  smoothScroll.polyfill();
   element.scrollBy({top: -amount, left: 0, behavior});
 }
 
 export async function scrollDown(element: Window | Element, amount: number, {behavior = "smooth"}: ScrollOptions = {}) {
-  smoothScroll.polyfill();
   element.scrollBy({top: amount, left: 0, behavior});
 }
 
 export async function scrollLeft(element: Window | Element, amount: number, {behavior = "smooth"}: ScrollOptions = {}) {
-  smoothScroll.polyfill();
   element.scrollBy({top: 0, left: -amount, behavior});
 }
 
 export async function scrollRight(element: Window | Element, amount: number, {behavior = "smooth"}: ScrollOptions = {}) {
-  smoothScroll.polyfill();
   element.scrollBy({top: 0, left: amount, behavior});
 }
 
 export function getScrollParent(node: HTMLElement | null): Window | HTMLElement | null {
-  smoothScroll.polyfill();
   if (!node) {
     return null;
   }

--- a/src/utilities/strings.ts
+++ b/src/utilities/strings.ts
@@ -1,5 +1,16 @@
-import camelCase from "lodash-es/camelCase";
-import upperFirst from "lodash-es/upperFirst";
+export function upperFirst(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+export function lowerFirst(str) {
+  return str.charAt(0).toLowerCase() + str.slice(1);
+}
+
+export function camelCase(str) {
+  return lowerFirst(
+    str.replace(/[-_\s]([A-Za-z])/g, (g) => g[1].toUpperCase() + g.slice(2)),
+  );
+}
 
 export function pascalCase(str: string): string {
   return upperFirst(

--- a/src/utilities/strings.ts
+++ b/src/utilities/strings.ts
@@ -1,14 +1,14 @@
-export function upperFirst(str) {
+export function upperFirst(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-export function lowerFirst(str) {
+export function lowerFirst(str: string) {
   return str.charAt(0).toLowerCase() + str.slice(1);
 }
 
-export function camelCase(str) {
+export function camelCase(str: string) {
   return lowerFirst(
-    str.replace(/[-_\s]([A-Za-z])/g, (g) => g[1].toUpperCase() + g.slice(2)),
+    str.replace(/[-_\s]([A-Za-z])/g, (g: string) => g[1].toUpperCase() + g.slice(2)),
   );
 }
 


### PR DESCRIPTION
These changes should make import map setups lighter-weight. 

Polyfills are largely no-longer needed, and can be self-administered by any users that need them. 
The lodash functions this library imports can largely be internalized with generic implementations. 

This may have breaking changes, please check all your controllers are behaving as expected after migrating. 