### PR TITLE
Fix selects with defaultSelected when using use_dirty_form_tracking

### DIFF
--- a/packages/mixins/src/use_dirty_form_tracking.ts
+++ b/packages/mixins/src/use_dirty_form_tracking.ts
@@ -93,7 +93,6 @@ function getElementLoadValue(element: HTMLInputElement | HTMLSelectElement | HTM
     let options = Array.from(element.options);
     options.forEach((option) => {
       if (option.defaultSelected) {
-        element.value = option.value;
         return option.value;
       }
     });


### PR DESCRIPTION
I could be mistaken and my issue could be specific to my usage of the controller, however I noticed within: 

```
function getElementLoadValue(element) {
    let value = element.getAttribute(CACHE_ATTR_NAME);
    if (isElementCheckable(element)) {
        return value == null ? element.defaultChecked : value == "true";
    }
    else if (isHTMLSelectElement(element)) {
        let options = Array.from(element.options);
        options.forEach((option) => {
            if (option.defaultSelected) {
                element.value = option.value;
                return option.value;
            }
        });
    }
    else if (value !== null) {
        return value;
    }
    return value;
}
```

We are updating the value of the element if there is a default selected option:
`element.value = option.value;`

Removing this line fixed my use case. I double checked the docs and it seems the select used there doesn't have a default selected which is why it is likely working?