### PR TITLE
Nested form controller fixes

### DIFF
--- a/docs/docs/examples/nested_form_controller.erb.mdx
+++ b/docs/docs/examples/nested_form_controller.erb.mdx
@@ -8,7 +8,7 @@ Parent association fields
 -->
 
 <h4> Tasks</h4>
-<div data-controller="nested-form">
+<div data-controller="nested-form" data-nested-form-wrapper-class-value="nested-fields">
   <script type="text/x-template" data-nested-form-target="template">
     <%= f.simple_fields_for :tasks, Task.new, child_index: 'NEW_RECORD' do |task| %>
       <%= render "task_fields", f: task %>

--- a/docs/docs/examples/nested_form_controller.haml.mdx
+++ b/docs/docs/examples/nested_form_controller.haml.mdx
@@ -8,7 +8,7 @@
 -#-->
 
 %h4 Tasks
-%div{ data: { controller: "nested-form" } }
+%div{ data: { controller: "nested-form", nested_form_wrapper_class_value: "nested-fields" } }
   %script{ type: "text/x-template", data: { nested_form_target: "template" } }
     = f.simple_fields_for :tasks, Task.new, child_index: 'NEW_RECORD' do |task|
       = render "task_fields", f: task

--- a/packages/controllers/src/forms/nested_form_controller.ts
+++ b/packages/controllers/src/forms/nested_form_controller.ts
@@ -11,12 +11,12 @@ export class NestedFormController extends BaseController {
   declare readonly templateTarget: HTMLTemplateElement | HTMLScriptElement;
 
   declare readonly wrapperClassValue: string;
-  declare readonly hasWrapperSelectorValue: boolean;
+  declare readonly hasWrapperClassValue: boolean;
   declare readonly insertModeValue: InsertPosition;
   declare readonly hasInsertModeValue: boolean;
 
   get _wrapperClass() {
-    return this.hasWrapperSelectorValue ? this.wrapperClassValue : "nested-fields";
+    return this.hasWrapperClassValue ? this.wrapperClassValue : "nested-fields";
   }
 
   get _insertMode(): InsertPosition {

--- a/packages/controllers/src/forms/nested_form_controller.ts
+++ b/packages/controllers/src/forms/nested_form_controller.ts
@@ -3,8 +3,8 @@ import { BaseController } from "@stimulus-library/utilities";
 export class NestedFormController extends BaseController {
   static targets = ["target", "template"];
   static values = {
-    insertMode: String,
-    wrapperClass: String,
+    insertMode: { type: String, default: "beforeend" },
+    wrapperClass: { type: String, default: "nested-fields" },
   };
 
   declare readonly targetTarget: HTMLElement;
@@ -15,14 +15,6 @@ export class NestedFormController extends BaseController {
   declare readonly insertModeValue: InsertPosition;
   declare readonly hasInsertModeValue: boolean;
 
-  get _wrapperClass() {
-    return this.hasWrapperClassValue ? this.wrapperClassValue : "nested-fields";
-  }
-
-  get _insertMode(): InsertPosition {
-    return this.hasInsertModeValue ? this.insertModeValue : "beforeend";
-  }
-
   connect() {
     this._checkStructure();
   }
@@ -31,14 +23,14 @@ export class NestedFormController extends BaseController {
     event?.preventDefault();
 
     const content = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, this._generateID());
-    this.targetTarget.insertAdjacentHTML(this._insertMode, content);
+    this.targetTarget.insertAdjacentHTML(this.insertModeValue, content);
   }
 
   remove(event: Event) {
     event.preventDefault();
-    const wrapper: HTMLElement | null = (event.target as HTMLElement).closest(`.${this._wrapperClass}`);
+    const wrapper: HTMLElement | null = (event.target as HTMLElement).closest(`.${this.wrapperClassValue}`);
     if (wrapper == null) {
-      throw new Error(`#remove was clicked from outside of a child record. Could not find an ancestor with class .${this._wrapperClass}`);
+      throw new Error(`#remove was clicked from outside of a child record. Could not find an ancestor with class .${this.wrapperClassValue}`);
     }
 
     if (wrapper.dataset.newRecord === "true") {

--- a/packages/controllers/src/forms/nested_form_controller.ts
+++ b/packages/controllers/src/forms/nested_form_controller.ts
@@ -61,7 +61,7 @@ export class NestedFormController extends BaseController {
   private _checkStructure() {
     const template = this.templateTarget.innerHTML;
 
-    if (template.indexOf("NEW_RECORD")) {
+    if (!template.includes("NEW_RECORD")) {
       throw new Error("Could not find 'NEW_RECORD' in the provided template. Please make sure you've passed `child_index: 'NEW_RECORD'` to `fields_for`");
     }
   }


### PR DESCRIPTION
Hi, thanks for maintaining this library!

I ran into a few bugs while trying to use `NestedFormController`:
- The `Could not find 'NEW_RECORD' in the provided template` error is always thrown — the logic appears to be backwards
- Setting `data-nested-form-wrapper-class-value` does not work to override the `wrapperClassValue`