### PR TITLE
Adding opts when removing event listener

### DIFF
--- a/packages/mixins/src/use_event_listener.ts
+++ b/packages/mixins/src/use_event_listener.ts
@@ -12,7 +12,7 @@ export function useEventListener(controller: Controller, element: Document | Win
 
   const eventNames = wrapArray(eventNameOrNames);
   const setup = () => eventNames.forEach(eventName => element.addEventListener(eventName, handler, opts));
-  const teardown = () => eventNames.forEach(eventName => element.removeEventListener(eventName, handler));
+  const teardown = () => eventNames.forEach(eventName => element.removeEventListener(eventName, handler, opts));
 
   useMixin(controller, setup, teardown);
   return { setup, teardown };


### PR DESCRIPTION
I'm not totally sure if this is the correct fix, but recently was trying to add a `capture` option when listening to an event on window. If you don't add the option when removing the event listener I don't believe it properly removes the listener. 

Please let me know if there's a better way to do this, would love to learn!