### PR TITLE
chore(Examples): CheckboxXOR Example - Make `<label>` clickable

### DIFF
--- a/examples/controllers/checkbox_xor_controller.html
+++ b/examples/controllers/checkbox_xor_controller.html
@@ -9,49 +9,59 @@
   <body>
     <div class="container p-4 text-center" data-controller="checkbox-xor">
       <div class="form-check">
-        <input
-          type="checkbox"
-          class="check-input"
-          name="Chocolate"
-          data-checkbox-xor-target="checkbox"
-        />
-        <label class="check-label"> Chocolate</label>
+        <label class="check-label">
+          <input
+            type="checkbox"
+            class="check-input"
+            name="Chocolate"
+            data-checkbox-xor-target="checkbox"
+          />
+          Chocolate
+        </label>
       </div>
       <div class="form-check">
-        <input
-          type="checkbox"
-          class="check-input"
-          name="Vanilla"
-          data-checkbox-xor-target="checkbox"
-        />
-        <label class="check-label"> Vanilla</label>
+        <label class="check-label">
+          <input
+            type="checkbox"
+            class="check-input"
+            name="Vanilla"
+            data-checkbox-xor-target="checkbox"
+          />
+          Vanilla
+        </label>
       </div>
       <div class="form-check">
-        <input
-          type="checkbox"
-          class="check-input"
-          name="Fudge"
-          data-checkbox-xor-target="checkbox"
-        />
-        <label class="check-label"> Fudge</label>
+        <label class="check-label">
+          <input
+            type="checkbox"
+            class="check-input"
+            name="Fudge"
+            data-checkbox-xor-target="checkbox"
+          />
+          Fudge
+        </label>
       </div>
       <div class="form-check">
-        <input
-          type="checkbox"
-          class="check-input"
-          name="Banana"
-          data-checkbox-xor-target="checkbox"
-        />
-        <label class="check-label"> Banana</label>
+        <label class="check-label">
+          <input
+            type="checkbox"
+            class="check-input"
+            name="Banana"
+            data-checkbox-xor-target="checkbox"
+          />
+          Banana
+        </label>
       </div>
       <div class="form-check">
-        <input
-          type="checkbox"
-          class="check-input"
-          name="Strawberry"
-          data-checkbox-xor-target="checkbox"
-        />
-        <label class="check-label"> Strawberry</label>
+        <label class="check-label">
+          <input
+            type="checkbox"
+            class="check-input"
+            name="Strawberry"
+            data-checkbox-xor-target="checkbox"
+          />
+          Strawberry
+        </label>
       </div>
     </div>
 


### PR DESCRIPTION
One easy way to make label and input "connected", without the use of `id` and `for` attributes, is to wrap the `<input type="checkbox">` or `<input type="radio">` inside the `<label>`.

On the current site, clicking on label does nothing:
https://sub-xaero.github.io/stimulus-library/docs/controllers/form/CheckboxXORController