### PR TITLE
don't set load value when restoring

### DIFF
--- a/examples/controllers/detect_dirty_form_controller.html
+++ b/examples/controllers/detect_dirty_form_controller.html
@@ -81,6 +81,8 @@
             <option value="AUDI">AUDI</option>
           </select>
         </div>
+
+        <button id="restore-button" data-action="click->detect-dirty-form#restore">Reset</button>
       </form>
     </div>
     <style>

--- a/packages/mixins/src/use_dirty_form_tracking.ts
+++ b/packages/mixins/src/use_dirty_form_tracking.ts
@@ -166,8 +166,8 @@ export function restoreElementFromLoadValue(element: HTMLInputElement | HTMLSele
   const cacheValue = element.getAttribute(CACHE_ATTR_NAME);
 
   if (isElementCheckable(element)) {
-    element.setAttribute(CACHE_ATTR_NAME, element.checked.toString());
-    element.checked = cacheValue == null ? element.defaultChecked : cacheValue == "true";
+    element.checked =
+      cacheValue == null ? element.defaultChecked : cacheValue == "true";
   } else if (isHTMLSelectElement(element)) {
     if (cacheValue == null) {
       const options = Array.from(element.options);

--- a/packages/stimulus-library/cypress/e2e/detect_dirty_form_controller.cy.js
+++ b/packages/stimulus-library/cypress/e2e/detect_dirty_form_controller.cy.js
@@ -29,4 +29,34 @@ describe("Detect dirty form controller", () => {
     });
 
   });
+
+  it("Should clear the data-dirty attribute when the restore action is triggered", () => {
+    cy.get("form").should("not.have.attr", "data-dirty");
+
+    cy.get("input[type=\"text\"],input[type=\"number\"],input[type=\"checkbox\"],input[type=\"radio\"]:not(:checked),select,textarea").each((el, index, list) => {
+      switch (el[0].tagName) {
+      case "INPUT":
+        if (el[0].type === "checkbox" || el[0].type === "radio") {
+          cy.wrap(el).check();
+        } else {
+          cy.wrap(el).type("123");
+        }
+        break;
+
+      case "TEXTAREA":
+        cy.wrap(el).type("Lorem ipsum");
+        break;
+
+      case "SELECT":
+        cy.wrap(el).select("VOLVO");
+        break;
+      }
+      cy.wrap(el).should("have.attr", "data-dirty");
+      cy.get("form").should("have.attr", "data-dirty");
+      cy.get("#restore-button").click();
+      cy.wrap(el).should("not.have.attr", "data-dirty");
+      cy.get("form").should("not.have.attr", "data-dirty");
+    });
+
+  });
 });


### PR DESCRIPTION
I noticed when restoring a form with a dirty checkbox the load value attribute kept being switched to the current value before it was restored which caused it to always remain dirty.

I tried adding a cypress test for this but it is still failing and I'm not really sure why.