### PR TITLE
fix(useDirtyFormTracking mixin): Fix logic in caching of load values causing checkboxes to cache their value instead of checked

### DIFF
--- a/packages/mixins/src/use_dirty_form_tracking.ts
+++ b/packages/mixins/src/use_dirty_form_tracking.ts
@@ -191,9 +191,11 @@ function restoreMultiSelect(element: HTMLSelectElement, cacheValue: string) {
   );
 }
 
-function cacheLoadValues(element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement): void {
-  if (!elementHasCachedLoadValue(element) && isElementCheckable(element)) {
-    element.setAttribute(CACHE_ATTR_NAME, element.checked.toString());
+export function cacheLoadValues(element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement): void {
+  if (isElementCheckable(element)) {
+    if (!elementHasCachedLoadValue(element)) {
+      element.setAttribute(CACHE_ATTR_NAME, element.checked.toString());
+    }
   } else if (isHTMLSelectElement(element) && element.multiple) {
     element.setAttribute(CACHE_ATTR_NAME, JSON.stringify(getMultiSelectLoadValues(element)));
   } else {


### PR DESCRIPTION
Closes #535
