### PR TITLE
feat(FallbackIframeController): add iframe fallback handling

### DIFF
--- a/docs/docs/controllers/media/fallback_iframe_controller.mdx
+++ b/docs/docs/controllers/media/fallback_iframe_controller.mdx
@@ -1,0 +1,59 @@
+---
+id: FallbackIframeController
+title: FallbackIframeController
+---
+
+
+import NoActions from "../../_partials/no-actions.md";
+import NoTargets from "../../_partials/no-targets.md";
+
+## Purpose
+
+If an iframe fails to load from the source, provide a fallback URL, or hide it from the DOM altogether to prevent the broken-iframe placeholder from showing.
+
+
+## [Actions](https://stimulus.hotwire.dev/reference/actions)
+<NoActions/>
+
+## [Targets](https://stimulus.hotwire.dev/reference/targets)
+<NoTargets/>
+
+## [Classes](https://stimulus.hotwire.dev/reference/classes)
+
+| Class                | Purpose                                                                       | Default |
+|----------------------|-------------------------------------------------------------------------------|---------|
+| `success` (Optional) | The class that will be applied to the iframe if the iframe loads successfully | -       |
+| `fail` (Optional)    | The class that will be applied to the iframe if the fallback is triggered     | -       |
+
+
+## [Values](https://stimulus.hotwire.dev/reference/values)
+
+| Value                    | Type   | Description                                                                              | Default                  |
+|--------------------------|--------|------------------------------------------------------------------------------------------|--------------------------|
+| `placeholder` (Optional) | String | The URL of a fallback page to be displayed if the `<iframe>`'s `src` cannot be loaded.  | The `<iframe>`'s `src`   |
+
+## Events
+
+| Event                         | When                                                            | Dispatched on               | `event.detail` |
+|-------------------------------|-----------------------------------------------------------------|-----------------------------|----------------|
+| `fallback-iframe:placeholder` | When the iframe fails to load and falls back to the placeholder | The controller root element | -              |
+| `fallback-iframe:fail`        | When the iframe and the placeholder (if any) fails to load      | The controller root element | -              |
+
+
+## Side Effects
+
+- Sets an `onError` handler for the mounted `<iframe>` tag.
+- Sets the style of the iframe to be `display: none` if the iframe fails to load.
+
+
+## How to Use
+
+If an iframe fails to load, the controller will either try to set the `src` to a placeholder URL you provide, or hide the iframe using `display: none`.
+
+If the placeholder URL you provide *also* fails to load, the controller will fall back to the default behaviour of hiding the element.
+
+<iframe
+  src="https://stimulus-library.netlify.app/controllers/fallback_iframe_controller.html"
+  style={{width: "100%", height: "500px", border: "0", borderRadius: "4px", overflow: "hidden"}}
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+/>

--- a/examples/controllers/fallback_iframe_controller.html
+++ b/examples/controllers/fallback_iframe_controller.html
@@ -1,0 +1,22 @@
+<!-- Example 1: No fallback, just hide -->
+<iframe
+  id="iframe-1"
+  src="https://localhost/nonexistent-page"
+  data-controller="fallback-iframe"
+></iframe>
+
+<!-- Example 2: Fallback that also fails -->
+<iframe
+  id="iframe-2"
+  src="https://localhost/nonexistent-page"
+  data-fallback-iframe-placeholder-value="https://localhost/also-missing"
+  data-controller="fallback-iframe"
+></iframe>
+
+<!-- Example 3: Successful fallback -->
+<iframe
+  id="iframe-3"
+  src="https://localhost/nonexistent-page"
+  data-fallback-iframe-placeholder-value="https://example.com/"
+  data-controller="fallback-iframe"
+></iframe>

--- a/packages/controllers/src/media/fallback_iframe_controller.ts
+++ b/packages/controllers/src/media/fallback_iframe_controller.ts
@@ -1,0 +1,48 @@
+import { BaseController } from "@stimulus-library/utilities";
+
+export class FallbackIframeController extends BaseController {
+
+  static values = { placeholder: String };
+  static classes = ["success", "fail"];
+
+  declare readonly placeholderValue: string;
+  declare readonly hasPlaceholderValue: boolean;
+  declare addSuccessClasses: (el?: HTMLElement) => void;
+  declare removeSuccessClasses: (el?: HTMLElement) => void;
+  declare addFailClasses: (el?: HTMLElement) => void;
+  declare removeFailClasses: (el?: HTMLElement) => void;
+
+  initialize() {
+    this._success = this._success.bind(this);
+    this._fail = this._fail.bind(this);
+  }
+
+  connect() {
+    const element = this.el as HTMLIFrameElement;
+    element.onerror = this._fail;
+  }
+
+  disconnect() {
+    this.removeSuccessClasses();
+    this.removeFailClasses();
+  }
+
+  private _success() {
+    this.addSuccessClasses();
+  }
+
+  private _fail() {
+    const element = this.el as HTMLIFrameElement;
+    this.addFailClasses();
+
+    if (this.hasPlaceholderValue && element.src !== this.placeholderValue) {
+      this.dispatchEvent(element, this.eventName("placeholder"));
+      element.src = this.placeholderValue;
+      element.onerror = this._fail;
+    } else {
+      this.dispatchEvent(element, this.eventName("fail"));
+      element.style.display = "none";
+    }
+  }
+
+}

--- a/packages/controllers/src/media/index.ts
+++ b/packages/controllers/src/media/index.ts
@@ -1,3 +1,4 @@
+export * from "./fallback_iframe_controller";
 export * from "./fallback_image_controller";
 export * from "./lightbox_image_controller";
 export * from "./media_player_controller";

--- a/packages/stimulus-library/cypress/e2e/fallback_iframe_controller.cy.js
+++ b/packages/stimulus-library/cypress/e2e/fallback_iframe_controller.cy.js
@@ -1,0 +1,15 @@
+describe("Fallback Iframe Controller", () => {
+  beforeEach(() => {
+    cy.visit("controllers/fallback_iframe_controller.html");
+  });
+  it("Hides the element if a suitable fallback iframe cannot be shown when the src fails to load", () => {
+    cy.get("#iframe-1").should("not.be.visible");
+  });
+  it("Hides the element if both the src and the fallback src fail to load", () => {
+    cy.get("#iframe-2").should("not.be.visible");
+  });
+  it("Displays a fallback iframe if the src fails to load", () => {
+    cy.get("#iframe-3").should("have.attr", "src", "https://example.com/");
+    cy.get("#iframe-3").should("be.visible");
+  });
+});


### PR DESCRIPTION
## Summary

Implements FallbackIframeController, a new Stimulus controller that handles fallback behavior for iframes when they fail to load, similar to the existing FallbackImageController.

## Changes

- **Controller**: FallbackIframeController with support for placeholder URLs and CSS classes
- **Tests**: Cypress E2E test suite covering all fallback scenarios
- **Docs**: MDX documentation with usage examples
- **Examples**: HTML example demonstrating the three main use cases

The controller sets an `onerror` handler on iframes and either swaps to a placeholder URL or hides the element entirely if the source fails to load.

Closes #84 