### PR TITLE
feat: add signal sync controllers

### DIFF
--- a/docs/docs/controllers/signal/signal_attribute_sync_controller.mdx
+++ b/docs/docs/controllers/signal/signal_attribute_sync_controller.mdx
@@ -1,0 +1,64 @@
+---
+id: SignalAttributeSyncController
+title: SignalAttributeSyncController
+---
+
+import NoTargets from "../../_partials/no-targets.md";
+import NoActions from "../../_partials/no-actions.md";
+import NoSideEffects from "../../_partials/no-side-effects.md";
+import NoClasses from "../../_partials/no-classes.md";
+
+## Purpose
+
+A controller that responds to SignalInputController notifications. This controller unconditionally sets an HTML attribute on its element to the current signal value.
+
+This controller can be anywhere in the DOM tree and it will receive notifications from any SignalInputController with
+the same `nameValue` as the `nameValue` of this controller.
+
+### Example Use Cases
+- Set `href`, `src`, `placeholder`, or any other attribute dynamically based on an input value
+- Set `readonly` on an input based on another input's value (e.g. `data-signal-attribute-sync-attribute-value="readonly"`)
+- Update `aria-*` attributes reactively
+
+## [Actions](https://stimulus.hotwire.dev/reference/actions)
+<NoActions/>
+
+## [Targets](https://stimulus.hotwire.dev/reference/targets)
+<NoTargets/>
+
+## [Classes](https://stimulus.hotwire.dev/reference/classes)
+<NoClasses/>
+
+## [Values](https://stimulus.hotwire.dev/reference/values)
+
+| Value       | Type   | Description                                                                                                                             | Default |
+|-------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `name`      | String | The name of the signal to react to. This should match the `nameValue` of the SignalInputController you want to sync with. | `-`     |
+| `attribute` | String | The name of the HTML attribute to set on the controller element.                                                                        | `-`     |
+
+## Events
+
+This controller does not dispatch any events.
+
+## Side Effects
+<NoSideEffects/>
+
+## How to Use
+
+```html
+<input
+  type="text"
+  data-controller="signal-input"
+  data-signal-input-name-value="label"
+  placeholder="Enter a label..."
+/>
+
+<button
+  data-controller="signal-attribute-sync"
+  data-signal-attribute-sync-name-value="label"
+  data-signal-attribute-sync-attribute-value="aria-label"
+>
+  <!-- aria-label is kept in sync with the input value -->
+  Click me
+</button>
+```

--- a/docs/docs/controllers/signal/signal_class_controller.mdx
+++ b/docs/docs/controllers/signal/signal_class_controller.mdx
@@ -1,0 +1,79 @@
+---
+id: SignalClassController
+title: SignalClassController
+---
+
+import NoTargets from "../../_partials/no-targets.md";
+import NoActions from "../../_partials/no-actions.md";
+import NoSideEffects from "../../_partials/no-side-effects.md";
+import Expressions from "../../_partials/expressions.md";
+import NoClasses from "../../_partials/no-classes.md";
+
+## Purpose
+
+A controller that responds to SignalInputController notifications. This controller adds or removes an arbitrary CSS class on its element based on the expression given in `whenValue`, evaluated against the current signal value.
+
+This controller can be anywhere in the DOM tree and it will receive notifications from any SignalInputController with
+the same `nameValue` as the `nameValue` of this controller.
+
+See also: `SignalVisibilityController` if you only need to toggle visibility using a `hide` class.
+
+### Example Use Cases
+- Highlight a field with an `error` class when a related input has an out-of-range value
+- Add an `active` class to a nav item when a signal matches a specific value
+- Apply a `warning` class when a numeric threshold is exceeded
+
+## [Actions](https://stimulus.hotwire.dev/reference/actions)
+<NoActions/>
+
+## [Targets](https://stimulus.hotwire.dev/reference/targets)
+<NoTargets/>
+
+## [Classes](https://stimulus.hotwire.dev/reference/classes)
+<NoClasses/>
+
+## [Values](https://stimulus.hotwire.dev/reference/values)
+
+| Value   | Type   | Description                                                                                                                                                                                                                         | Default |
+|---------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `name`  | String | The name of the signal to react to. This should match the `nameValue` of the SignalInputController you want to sync with.                                                                                         | `-`     |
+| `when`  | String | A simple _expression_ which will be evaluated against the value received from SignalInputController. If the expression evaluates to true, the class in `classValue` is added to the element; otherwise it is removed. | `-`     |
+| `class` | String | The CSS class name to add or remove on the controller element.                                                                                                                                                                       | `-`     |
+
+<Expressions/>
+
+## Events
+
+| Event                                  | When                                                                                                                                       | Dispatched on               | `event.detail` |                                                               |
+|----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|----------------|---------------------------------------------------------------|
+| `signal:class-add:${nameValue}`    | When the signal value matches the `whenValue` expression and the class is added     | The controller root element |                |                                                               |
+|                                        |                                                                                                                                            |                             | `predicate`    | the expression the controller used to try and match the value |
+|                                        |                                                                                                                                            |                             | `value`        | the value that was received                                   |
+|                                        |                                                                                                                                            |                             | `class`        | the CSS class that was added                                  |
+| `signal:class-remove:${nameValue}` | When the signal value does not match the `whenValue` expression and the class is removed | The controller root element |                |                                                               |
+|                                        |                                                                                                                                            |                             | `predicate`    | the expression the controller used to try and match the value |
+|                                        |                                                                                                                                            |                             | `value`        | the value that was received                                   |
+|                                        |                                                                                                                                            |                             | `class`        | the CSS class that was removed                                |
+
+## Side Effects
+<NoSideEffects/>
+
+## How to Use
+
+```html
+<input
+  type="number"
+  data-controller="signal-input"
+  data-signal-input-name-value="age"
+  placeholder="Enter your age"
+/>
+
+<div
+  data-controller="signal-class"
+  data-signal-class-name-value="age"
+  data-signal-class-when-value=">=18"
+  data-signal-class-class-value="eligible"
+>
+  <!-- the "eligible" class is added when the age input is 18 or over -->
+</div>
+```

--- a/docs/docs/controllers/signal/signal_content_sync_controller.mdx
+++ b/docs/docs/controllers/signal/signal_content_sync_controller.mdx
@@ -1,0 +1,60 @@
+---
+id: SignalContentSyncController
+title: SignalContentSyncController
+---
+
+import NoTargets from "../../_partials/no-targets.md";
+import NoActions from "../../_partials/no-actions.md";
+import NoSideEffects from "../../_partials/no-side-effects.md";
+import NoClasses from "../../_partials/no-classes.md";
+
+## Purpose
+
+A controller that responds to SignalInputController notifications. This controller unconditionally syncs the `innerText` of its element to the current signal value.
+
+This controller can be anywhere in the DOM tree and it will receive notifications from any SignalInputController with
+the same `nameValue` as the `nameValue` of this controller.
+
+### Example Use Cases
+- Display the current value of a form input as readable text elsewhere on the page
+- Mirror a search query into a results heading
+
+## [Actions](https://stimulus.hotwire.dev/reference/actions)
+<NoActions/>
+
+## [Targets](https://stimulus.hotwire.dev/reference/targets)
+<NoTargets/>
+
+## [Classes](https://stimulus.hotwire.dev/reference/classes)
+<NoClasses/>
+
+## [Values](https://stimulus.hotwire.dev/reference/values)
+
+| Value  | Type   | Description                                                                                                                             | Default |
+|--------|--------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `name` | String | The name of the signal to react to. This should match the `nameValue` of the SignalInputController you want to sync with. | `-`     |
+
+## Events
+
+This controller does not dispatch any events.
+
+## Side Effects
+<NoSideEffects/>
+
+## How to Use
+
+```html
+<input
+  type="text"
+  data-controller="signal-input"
+  data-signal-input-name-value="search"
+  placeholder="Type to search..."
+/>
+
+<p
+  data-controller="signal-content-sync"
+  data-signal-content-sync-name-value="search"
+>
+  <!-- innerText is kept in sync with the input value -->
+</p>
+```

--- a/examples/controllers/signal_sync_controllers.html
+++ b/examples/controllers/signal_sync_controllers.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8"/>
+    <link href="favicon.svg" rel="icon" type="image/svg+xml"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <title>Signal Sync Controllers</title>
+  </head>
+  <body>
+    <div class="container p-4">
+
+      <!-- SignalContentSyncController: mirrors input value as text -->
+      <section id="content-sync-section">
+        <input
+          id="content-sync-input"
+          type="text"
+          data-controller="signal-input"
+          data-signal-input-name-value="greeting"
+        />
+        <p
+          id="content-sync-output"
+          data-controller="signal-content-sync"
+          data-signal-content-sync-name-value="greeting"
+        ></p>
+      </section>
+
+      <!-- SignalAttributeSyncController: sets an attribute from signal value -->
+      <section id="attribute-sync-section">
+        <input
+          id="attribute-sync-input"
+          type="text"
+          data-controller="signal-input"
+          data-signal-input-name-value="placeholder-text"
+        />
+        <input
+          id="attribute-sync-target"
+          type="text"
+          data-controller="signal-attribute-sync"
+          data-signal-attribute-sync-name-value="placeholder-text"
+          data-signal-attribute-sync-attribute-value="placeholder"
+        />
+      </section>
+
+      <!-- SignalClassController: toggles a CSS class based on a predicate -->
+      <section id="class-section">
+        <input
+          id="class-input"
+          type="number"
+          data-controller="signal-input"
+          data-signal-input-name-value="score"
+        />
+        <div
+          id="class-target"
+          data-controller="signal-class"
+          data-signal-class-name-value="score"
+          data-signal-class-when-value=">=50"
+          data-signal-class-class-value="passing"
+        >Result</div>
+      </section>
+
+      <!-- SignalClassController: default predicate (non-empty value) -->
+      <section id="class-default-section">
+        <input
+          id="class-default-input"
+          type="text"
+          data-controller="signal-input"
+          data-signal-input-name-value="name-field"
+        />
+        <div
+          id="class-default-target"
+          data-controller="signal-class"
+          data-signal-class-name-value="name-field"
+          data-signal-class-when-value="default"
+          data-signal-class-class-value="has-value"
+        >Name field status</div>
+      </section>
+
+    </div>
+    <script src="/main.js" type="module"></script>
+  </body>
+</html>

--- a/examples/main.js
+++ b/examples/main.js
@@ -69,7 +69,12 @@ import {
   ScrollToTopController,
   SelfDestructController,
   SignalActionController,
+  SignalAttributeSyncController,
+  SignalClassController,
+  SignalContentSyncController,
+  SignalDisableController,
   SignalDomChildrenController,
+  SignalEnableController,
   SignalInputController,
   SignalVisibilityController,
   StickyController,
@@ -158,7 +163,12 @@ app.register('refresh-page', RefreshPageController);
 app.register('responsive-iframe-body', ResponsiveIframeBodyController);
 app.register('responsive-iframe-wrapper', ResponsiveIframeWrapperController);
 app.register('signal-action', SignalActionController);
+app.register('signal-attribute-sync', SignalAttributeSyncController);
+app.register('signal-class', SignalClassController);
+app.register('signal-content-sync', SignalContentSyncController);
+app.register('signal-disable', SignalDisableController);
 app.register('signal-dom-children', SignalDomChildrenController);
+app.register('signal-enable', SignalEnableController);
 app.register('signal-input', SignalInputController);
 app.register('signal-visibility', SignalVisibilityController);
 app.register('scroll-container', ScrollContainerController);

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -10,12 +10,114 @@
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
+        "@stimulus-library/controllers": "file:../packages/controllers",
+        "@stimulus-library/mixins": "file:../packages/mixins",
+        "@stimulus-library/utilities": "file:../packages/utilities",
         "bootstrap": "^5.2.3",
         "sass": "^1.58.0",
-        "stimulus-library": "*",
+        "stimulus-library": "file:../packages/stimulus-library",
         "tiny-glob": "^0.2.9",
         "trix": "^2.1.16",
         "vite": "^6.4.1"
+      }
+    },
+    "../packages/controllers": {
+      "name": "@stimulus-library/controllers",
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "@stimulus-library/mixins": "^1.5.0",
+        "@stimulus-library/utilities": "^1.5.0",
+        "date-fns": "^4.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.7",
+        "agadoo": "^3.0.0",
+        "cypress": "^15.3.0",
+        "fast-glob": "^3.2.12",
+        "lerna": "^9.0.4",
+        "rimraf": "^6.0.1",
+        "standard-version": "^9.5.0",
+        "typescript": "^5.8.2",
+        "vite": "^7.0.2"
+      }
+    },
+    "../packages/mixins": {
+      "name": "@stimulus-library/mixins",
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "@hotwired/stimulus": "^3.0.0",
+        "@stimulus-library/utilities": "^1.5.0"
+      },
+      "devDependencies": {
+        "@types/chai": "^5.0.1",
+        "@types/mocha": "^10.0.1",
+        "@types/node": "^24.0.7",
+        "@types/sinon": "^21.0.0",
+        "@types/sinon-chai": "^4.0.0",
+        "agadoo": "^3.0.0",
+        "chai": "^6.2.0",
+        "fast-glob": "^3.2.12",
+        "lerna": "^9.0.4",
+        "mocha": "^11.1.0",
+        "rimraf": "^6.0.1",
+        "sinon": "^21.0.0",
+        "sinon-chai": "^4.0.0",
+        "standard-version": "^9.5.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.2",
+        "vite": "^7.0.2"
+      }
+    },
+    "../packages/stimulus-library": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "@hotwired/stimulus": "^3.2.1",
+        "@stimulus-library/controllers": "^1.5.0",
+        "@stimulus-library/mixins": "^1.5.0",
+        "@stimulus-library/utilities": "^1.5.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.7",
+        "agadoo": "^3.0.0",
+        "cypress": "^15.3.0",
+        "fast-glob": "^3.2.12",
+        "lerna": "^9.0.4",
+        "rimraf": "^6.0.1",
+        "standard-version": "^9.5.0",
+        "typescript": "^5.8.2",
+        "vite": "^7.0.2"
+      }
+    },
+    "../packages/utilities": {
+      "name": "@stimulus-library/utilities",
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "@hotwired/stimulus": "^3.0.0",
+        "@stimulus-library/utilities": "^1.0.2",
+        "mitt": "^3.0.0"
+      },
+      "devDependencies": {
+        "@types/chai": "^5.0.1",
+        "@types/mocha": "^10.0.1",
+        "@types/node": "^24.0.7",
+        "@types/sinon": "^21.0.0",
+        "@types/sinon-chai": "^4.0.0",
+        "agadoo": "^3.0.0",
+        "chai": "^6.2.0",
+        "fast-glob": "^3.2.12",
+        "lerna": "^9.0.4",
+        "mocha": "^11.1.0",
+        "rimraf": "^6.0.1",
+        "sinon": "^21.0.0",
+        "sinon-chai": "^4.0.0",
+        "standard-version": "^9.5.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.2",
+        "vite": "^7.0.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -418,11 +520,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@hotwired/stimulus": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
-      "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A=="
-    },
     "node_modules/@popperjs/core": {
       "version": "2.11.6",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
@@ -733,33 +830,16 @@
       ]
     },
     "node_modules/@stimulus-library/controllers": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@stimulus-library/controllers/-/controllers-1.2.0.tgz",
-      "integrity": "sha512-E4KRDe5K9rYKDnoFIpKQvKVW9m3Z/iuCNXtssxeYkjxMXJ+nDa3Wh4ESOcQiMOIwkwzWY0XbbFyGsuYFrhD05g==",
-      "dependencies": {
-        "@stimulus-library/mixins": "^1.0.7",
-        "@stimulus-library/utilities": "^1.0.7",
-        "date-fns": "^3.0.0"
-      }
+      "resolved": "../packages/controllers",
+      "link": true
     },
     "node_modules/@stimulus-library/mixins": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@stimulus-library/mixins/-/mixins-1.0.7.tgz",
-      "integrity": "sha512-D89bibBYQ17o8Wk40LS8PuXgT84QCkCFMTBwD94mQ8NuIlQzEoeqADFf9eoB0dCj/X1KqfpeCh4WZFozd0JsRA==",
-      "dependencies": {
-        "@hotwired/stimulus": "^3.0.0",
-        "@stimulus-library/utilities": "^1.0.7"
-      }
+      "resolved": "../packages/mixins",
+      "link": true
     },
     "node_modules/@stimulus-library/utilities": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@stimulus-library/utilities/-/utilities-1.0.7.tgz",
-      "integrity": "sha512-S3edMDprHrvcMwpOQXXQ+EePiGKGy3VG7CkEvFFDuPOJsToBQdAI0/cmEgOLEYTwnx1XZNrG98UlTXCNS5Cj0g==",
-      "dependencies": {
-        "@hotwired/stimulus": "^3.0.0",
-        "@stimulus-library/utilities": "^1.0.2",
-        "mitt": "^3.0.0"
-      }
+      "resolved": "../packages/utilities",
+      "link": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -841,15 +921,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dompurify": {
@@ -994,11 +1065,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1151,15 +1217,8 @@
       }
     },
     "node_modules/stimulus-library": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stimulus-library/-/stimulus-library-1.2.0.tgz",
-      "integrity": "sha512-FRKtivCQdxIVcZPEvTGEd+LWD10vJ43YwIr7yC3dj769aTQRHOBvOoVuAjptigJ4/UwM943kv48EAxqYrl8Kmw==",
-      "dependencies": {
-        "@hotwired/stimulus": "^3.2.1",
-        "@stimulus-library/controllers": "^1.2.0",
-        "@stimulus-library/mixins": "^1.0.7",
-        "@stimulus-library/utilities": "^1.0.7"
-      }
+      "resolved": "../packages/stimulus-library",
+      "link": true
     },
     "node_modules/tiny-glob": {
       "version": "0.2.9",
@@ -1486,11 +1545,6 @@
       "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
       "optional": true
     },
-    "@hotwired/stimulus": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
-      "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A=="
-    },
     "@popperjs/core": {
       "version": "2.11.6",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
@@ -1647,32 +1701,69 @@
       "optional": true
     },
     "@stimulus-library/controllers": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@stimulus-library/controllers/-/controllers-1.2.0.tgz",
-      "integrity": "sha512-E4KRDe5K9rYKDnoFIpKQvKVW9m3Z/iuCNXtssxeYkjxMXJ+nDa3Wh4ESOcQiMOIwkwzWY0XbbFyGsuYFrhD05g==",
+      "version": "file:../packages/controllers",
       "requires": {
-        "@stimulus-library/mixins": "^1.0.7",
-        "@stimulus-library/utilities": "^1.0.7",
-        "date-fns": "^3.0.0"
+        "@stimulus-library/mixins": "^1.5.0",
+        "@stimulus-library/utilities": "^1.5.0",
+        "@types/node": "^24.0.7",
+        "agadoo": "^3.0.0",
+        "cypress": "^15.3.0",
+        "date-fns": "^4.1.0",
+        "fast-glob": "^3.2.12",
+        "lerna": "^9.0.4",
+        "rimraf": "^6.0.1",
+        "standard-version": "^9.5.0",
+        "typescript": "^5.8.2",
+        "vite": "^7.0.2"
       }
     },
     "@stimulus-library/mixins": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@stimulus-library/mixins/-/mixins-1.0.7.tgz",
-      "integrity": "sha512-D89bibBYQ17o8Wk40LS8PuXgT84QCkCFMTBwD94mQ8NuIlQzEoeqADFf9eoB0dCj/X1KqfpeCh4WZFozd0JsRA==",
+      "version": "file:../packages/mixins",
       "requires": {
         "@hotwired/stimulus": "^3.0.0",
-        "@stimulus-library/utilities": "^1.0.7"
+        "@stimulus-library/utilities": "^1.5.0",
+        "@types/chai": "^5.0.1",
+        "@types/mocha": "^10.0.1",
+        "@types/node": "^24.0.7",
+        "@types/sinon": "^21.0.0",
+        "@types/sinon-chai": "^4.0.0",
+        "agadoo": "^3.0.0",
+        "chai": "^6.2.0",
+        "fast-glob": "^3.2.12",
+        "lerna": "^9.0.4",
+        "mocha": "^11.1.0",
+        "rimraf": "^6.0.1",
+        "sinon": "^21.0.0",
+        "sinon-chai": "^4.0.0",
+        "standard-version": "^9.5.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.2",
+        "vite": "^7.0.2"
       }
     },
     "@stimulus-library/utilities": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@stimulus-library/utilities/-/utilities-1.0.7.tgz",
-      "integrity": "sha512-S3edMDprHrvcMwpOQXXQ+EePiGKGy3VG7CkEvFFDuPOJsToBQdAI0/cmEgOLEYTwnx1XZNrG98UlTXCNS5Cj0g==",
+      "version": "file:../packages/utilities",
       "requires": {
         "@hotwired/stimulus": "^3.0.0",
         "@stimulus-library/utilities": "^1.0.2",
-        "mitt": "^3.0.0"
+        "@types/chai": "^5.0.1",
+        "@types/mocha": "^10.0.1",
+        "@types/node": "^24.0.7",
+        "@types/sinon": "^21.0.0",
+        "@types/sinon-chai": "^4.0.0",
+        "agadoo": "^3.0.0",
+        "chai": "^6.2.0",
+        "fast-glob": "^3.2.12",
+        "lerna": "^9.0.4",
+        "mitt": "^3.0.0",
+        "mocha": "^11.1.0",
+        "rimraf": "^6.0.1",
+        "sinon": "^21.0.0",
+        "sinon-chai": "^4.0.0",
+        "standard-version": "^9.5.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.2",
+        "vite": "^7.0.2"
       }
     },
     "@types/estree": {
@@ -1726,11 +1817,6 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
-    },
-    "date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
     },
     "dompurify": {
       "version": "3.3.2",
@@ -1835,11 +1921,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
-    "mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
-    },
     "nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1926,14 +2007,21 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
     "stimulus-library": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stimulus-library/-/stimulus-library-1.2.0.tgz",
-      "integrity": "sha512-FRKtivCQdxIVcZPEvTGEd+LWD10vJ43YwIr7yC3dj769aTQRHOBvOoVuAjptigJ4/UwM943kv48EAxqYrl8Kmw==",
+      "version": "file:../packages/stimulus-library",
       "requires": {
         "@hotwired/stimulus": "^3.2.1",
-        "@stimulus-library/controllers": "^1.2.0",
-        "@stimulus-library/mixins": "^1.0.7",
-        "@stimulus-library/utilities": "^1.0.7"
+        "@stimulus-library/controllers": "^1.5.0",
+        "@stimulus-library/mixins": "^1.5.0",
+        "@stimulus-library/utilities": "^1.5.0",
+        "@types/node": "^24.0.7",
+        "agadoo": "^3.0.0",
+        "cypress": "^15.3.0",
+        "fast-glob": "^3.2.12",
+        "lerna": "^9.0.4",
+        "rimraf": "^6.0.1",
+        "standard-version": "^9.5.0",
+        "typescript": "^5.8.2",
+        "vite": "^7.0.2"
       }
     },
     "tiny-glob": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -16,7 +16,10 @@
     "@popperjs/core": "^2.11.6",
     "bootstrap": "^5.2.3",
     "sass": "^1.58.0",
-    "stimulus-library": "latest",
+    "@stimulus-library/controllers": "file:../packages/controllers",
+    "@stimulus-library/mixins": "file:../packages/mixins",
+    "@stimulus-library/utilities": "file:../packages/utilities",
+    "stimulus-library": "file:../packages/stimulus-library",
     "trix": "^2.1.16",
     "tiny-glob": "^0.2.9",
     "vite": "^6.4.1"

--- a/packages/controllers/src/signal/index.ts
+++ b/packages/controllers/src/signal/index.ts
@@ -1,4 +1,7 @@
 export * from "./signal_action_controller";
+export * from "./signal_attribute_sync_controller";
+export * from "./signal_class_controller";
+export * from "./signal_content_sync_controller";
 export * from "./signal_disable_controller";
 export * from "./signal_dom_children_controller";
 export * from "./signal_enable_controller";

--- a/packages/controllers/src/signal/signal_attribute_sync_controller.ts
+++ b/packages/controllers/src/signal/signal_attribute_sync_controller.ts
@@ -1,0 +1,18 @@
+import { SignalPayload } from "./signal_input_controller";
+import { SignalBaseController } from "./base_controller";
+
+export class SignalAttributeSyncController extends SignalBaseController {
+
+  static values = {
+    name: String,
+    attribute: String,
+  };
+
+  declare nameValue: string;
+  declare attributeValue: string;
+
+  _onSignal(payload: SignalPayload) {
+    this.el.setAttribute(this.attributeValue, payload.value);
+  }
+
+}

--- a/packages/controllers/src/signal/signal_class_controller.ts
+++ b/packages/controllers/src/signal/signal_class_controller.ts
@@ -1,0 +1,46 @@
+import { SignalPayload } from "./signal_input_controller";
+import { signalEventName } from "./events";
+import { SignalBaseController } from "./base_controller";
+
+export class SignalClassController extends SignalBaseController {
+
+  static values = {
+    name: String,
+    when: String,
+    class: String,
+  };
+
+  declare nameValue: string;
+  declare whenValue: string;
+  declare classValue: string;
+
+  get predicateString() {
+    return this.whenValue;
+  }
+
+  _onSignal(payload: SignalPayload) {
+    const value = payload.value;
+
+    if (this.whenValue === "default") {
+      if (value === "") {
+        this.el.classList.remove(this.classValue);
+      } else {
+        this.el.classList.add(this.classValue);
+      }
+      return;
+    }
+
+    if (this.predicatesMatch(value)) {
+      this.dispatchEvent(this.el, signalEventName(this.nameValue, "class-add"), {
+        detail: { predicate: this.whenValue, value, class: this.classValue },
+      });
+      this.el.classList.add(this.classValue);
+    } else {
+      this.dispatchEvent(this.el, signalEventName(this.nameValue, "class-remove"), {
+        detail: { predicate: this.whenValue, value, class: this.classValue },
+      });
+      this.el.classList.remove(this.classValue);
+    }
+  }
+
+}

--- a/packages/controllers/src/signal/signal_content_sync_controller.ts
+++ b/packages/controllers/src/signal/signal_content_sync_controller.ts
@@ -1,0 +1,16 @@
+import { SignalPayload } from "./signal_input_controller";
+import { SignalBaseController } from "./base_controller";
+
+export class SignalContentSyncController extends SignalBaseController {
+
+  static values = {
+    name: String,
+  };
+
+  declare nameValue: string;
+
+  _onSignal(payload: SignalPayload) {
+    this.el.innerText = payload.value;
+  }
+
+}

--- a/packages/stimulus-library/cypress.config.ts
+++ b/packages/stimulus-library/cypress.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   video: false,
-  experimentalStudio: true,
   blockHosts: [
     "*.google-analytics.com",
     "googleads.g.doubleclick.net",
@@ -27,6 +26,6 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       return require("./cypress/plugins/index.js")(on, config);
     },
-    baseUrl: "http://localhost:3000/",
+    baseUrl: "http://localhost:3030/",
   },
 });

--- a/packages/stimulus-library/cypress/e2e/signal_sync_controllers.cy.js
+++ b/packages/stimulus-library/cypress/e2e/signal_sync_controllers.cy.js
@@ -1,0 +1,80 @@
+describe("SignalContentSyncController", () => {
+  beforeEach(() => {
+    cy.visit("controllers/signal_sync_controllers.html");
+  });
+
+  it("syncs innerText to the signal value as the user types", () => {
+    cy.get("#content-sync-output").should("have.text", "");
+    cy.get("#content-sync-input").type("Hello");
+    cy.get("#content-sync-output").should("have.text", "Hello");
+  });
+
+  it("updates innerText when the value changes", () => {
+    cy.get("#content-sync-input").type("First");
+    cy.get("#content-sync-output").should("have.text", "First");
+    cy.get("#content-sync-input").clear().type("Second");
+    cy.get("#content-sync-output").should("have.text", "Second");
+  });
+
+  it("clears innerText when the input is cleared", () => {
+    cy.get("#content-sync-input").type("Something");
+    cy.get("#content-sync-output").should("have.text", "Something");
+    cy.get("#content-sync-input").clear();
+    cy.get("#content-sync-output").should("have.text", "");
+  });
+});
+
+describe("SignalAttributeSyncController", () => {
+  beforeEach(() => {
+    cy.visit("controllers/signal_sync_controllers.html");
+  });
+
+  it("sets the specified attribute to the signal value", () => {
+    cy.get("#attribute-sync-input").type("Enter your name");
+    cy.get("#attribute-sync-target").should("have.attr", "placeholder", "Enter your name");
+  });
+
+  it("updates the attribute when the value changes", () => {
+    cy.get("#attribute-sync-input").type("First placeholder");
+    cy.get("#attribute-sync-target").should("have.attr", "placeholder", "First placeholder");
+    cy.get("#attribute-sync-input").clear().type("Second placeholder");
+    cy.get("#attribute-sync-target").should("have.attr", "placeholder", "Second placeholder");
+  });
+});
+
+describe("SignalClassController", () => {
+  beforeEach(() => {
+    cy.visit("controllers/signal_sync_controllers.html");
+  });
+
+  it("adds the class when the predicate matches", () => {
+    cy.get("#class-target").should("not.have.class", "passing");
+    cy.get("#class-input").type("50").trigger("input");
+    cy.get("#class-target").should("have.class", "passing");
+  });
+
+  it("does not add the class when the predicate does not match", () => {
+    cy.get("#class-input").type("49").trigger("input");
+    cy.get("#class-target").should("not.have.class", "passing");
+  });
+
+  it("removes the class when the value changes to no longer match", () => {
+    cy.get("#class-input").type("75").trigger("input");
+    cy.get("#class-target").should("have.class", "passing");
+    cy.get("#class-input").clear().type("10").trigger("input");
+    cy.get("#class-target").should("not.have.class", "passing");
+  });
+
+  it("adds the class with the default predicate when a non-empty value is given", () => {
+    cy.get("#class-default-target").should("not.have.class", "has-value");
+    cy.get("#class-default-input").type("anything");
+    cy.get("#class-default-target").should("have.class", "has-value");
+  });
+
+  it("removes the class with the default predicate when the input is cleared", () => {
+    cy.get("#class-default-input").type("something");
+    cy.get("#class-default-target").should("have.class", "has-value");
+    cy.get("#class-default-input").clear();
+    cy.get("#class-default-target").should("not.have.class", "has-value");
+  });
+});


### PR DESCRIPTION
## Summary

Expands the Stimulus signal system with three new subscriber controllers that sync signal values to the DOM:
- **SignalContentSyncController** — Updates element innerText from signal values
- **SignalAttributeSyncController** — Sets HTML attributes from signal values (e.g., `readonly`, `href`, `aria-label`)
- **SignalClassController** — Toggles CSS classes based on signal predicates, supporting the same `when` expression system as other signal controllers

## Changes

- 3 new controller implementations + comprehensive TypeScript types
- Full MDX documentation for each controller with examples
- 10 Cypress e2e tests covering all behaviors and edge cases
- Example HTML fixtures demonstrating real-world usage
- Updated examples to register all signal controllers and use local packages for development
- Fixed Cypress baseUrl (3030) to match Vite dev server config
- Removed deprecated `experimentalStudio` option from Cypress config

## Testing

All 10 new tests pass. Signal sync controllers integrate seamlessly with existing signal input publishers and predicate system.